### PR TITLE
Fix HLS token rewriting for CRLF playlists

### DIFF
--- a/backend/src/routers/hls.py
+++ b/backend/src/routers/hls.py
@@ -107,17 +107,20 @@ def _rewrite_playlist(content: str, item_id: str, app_prefix: str, emby_url: str
     )
 
     if token:
-        # Emby emits CRLF playlists. split("\n") leaves a trailing "\r"
-        # on each URI, so appending the token puts it after a control
-        # character and HLS.js sees it as a separate, invalid line.
-        lines = content.splitlines()
+        # Emby emits CRLF playlists. Keep each terminator so the token is
+        # inserted before it and the upstream playlist formatting remains
+        # unchanged. Appending after "\r" makes HLS.js parse the token as
+        # a separate, invalid line.
+        lines = content.splitlines(keepends=True)
         for i, line in enumerate(lines):
             if line.strip().startswith("#") or not line.strip():
                 continue
-            if (".m3u8" in line or ".ts" in line) and "token=" not in line:
-                sep = "&" if "?" in line else "?"
-                lines[i] = line + f"{sep}token={token}"
-        content = "\n".join(lines)
+            uri = line.rstrip("\r\n")
+            terminator = line[len(uri):]
+            if (".m3u8" in uri or ".ts" in uri) and "token=" not in uri:
+                sep = "&" if "?" in uri else "?"
+                lines[i] = uri + f"{sep}token={token}" + terminator
+        content = "".join(lines)
 
     return content
 

--- a/backend/src/routers/hls.py
+++ b/backend/src/routers/hls.py
@@ -107,7 +107,10 @@ def _rewrite_playlist(content: str, item_id: str, app_prefix: str, emby_url: str
     )
 
     if token:
-        lines = content.split("\n")
+        # Emby emits CRLF playlists. split("\n") leaves a trailing "\r"
+        # on each URI, so appending the token puts it after a control
+        # character and HLS.js sees it as a separate, invalid line.
+        lines = content.splitlines()
         for i, line in enumerate(lines):
             if line.strip().startswith("#") or not line.strip():
                 continue

--- a/tests/test_hls_proxy.py
+++ b/tests/test_hls_proxy.py
@@ -127,6 +127,27 @@ class HLSProxyTests(unittest.TestCase):
             ],
         )
 
+    def test_playlist_rewrite_preserves_crlf_and_final_line_ending(self):
+        upstream_playlist = "#EXTM3U\r\nmain.m3u8?PlaySessionId=session\r\n"
+        upstream_response = httpx.Response(
+            200,
+            content=upstream_playlist.encode("utf-8"),
+            request=httpx.Request("GET", "http://emby.test/master.m3u8"),
+        )
+
+        with patch("backend.src.routers.hls.httpx.get", return_value=upstream_response):
+            response = _client().get(
+                "/hls/123/master.m3u8?PlaySessionId=session&token=party-token"
+            )
+
+        self.assertEqual(
+            response.content,
+            (
+                "#EXTM3U\r\n"
+                "main.m3u8?PlaySessionId=session&token=party-token\r\n"
+            ).encode("utf-8"),
+        )
+
     def test_segment_proxy_returns_playable_transport_stream_bytes(self):
         upstream_response = httpx.Response(
             200,

--- a/tests/test_hls_proxy.py
+++ b/tests/test_hls_proxy.py
@@ -1,0 +1,144 @@
+import unittest
+from unittest.mock import patch
+
+import httpx
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from backend.src.dependencies import (
+    get_config,
+    get_emby_client,
+    get_logger,
+    get_party_manager,
+    get_token_manager,
+)
+from backend.src.routers import hls
+
+
+class _Config:
+    EMBY_SERVER_URL = "http://emby.test"
+    APP_PREFIX = ""
+    ENABLE_HLS_TOKEN_VALIDATION = True
+
+
+class _EmbyClient:
+    def _headers(self, access_token, user_id):
+        return {}
+
+
+class _TokenManager:
+    def get_party_id(self, token):
+        return "PARTY" if token == "party-token" else None
+
+    def validate(self, token, **_kwargs):
+        return token == "party-token"
+
+
+class _PartyManager:
+    def exists(self, party_id):
+        return party_id == "PARTY"
+
+    def get(self, party_id):
+        if party_id != "PARTY":
+            return None
+        return {
+            "host_access_token": "host-token",
+            "host_user_id": "host-user",
+            "users": {},
+        }
+
+
+class _Logger:
+    def debug(self, _message):
+        pass
+
+    def error(self, _message):
+        pass
+
+
+def _client():
+    app = FastAPI()
+    app.include_router(hls.router)
+    app.dependency_overrides.update(
+        {
+            get_config: lambda: _Config(),
+            get_emby_client: lambda: _EmbyClient(),
+            get_token_manager: lambda: _TokenManager(),
+            get_party_manager: lambda: _PartyManager(),
+            get_logger: lambda: _Logger(),
+        }
+    )
+    return TestClient(app)
+
+
+class HLSProxyTests(unittest.TestCase):
+    def test_master_playlist_returns_usable_tokenized_variant_url(self):
+        upstream_playlist = (
+            "#EXTM3U\r\n"
+            "#EXT-X-STREAM-INF:BANDWIDTH=2000000\r\n"
+            "main.m3u8?MediaSourceId=source&PlaySessionId=session\r\n"
+        )
+        upstream_response = httpx.Response(
+            200,
+            text=upstream_playlist,
+            request=httpx.Request("GET", "http://emby.test/master.m3u8"),
+        )
+
+        with patch("backend.src.routers.hls.httpx.get", return_value=upstream_response):
+            response = _client().get(
+                "/hls/123/master.m3u8"
+                "?MediaSourceId=source&PlaySessionId=session&token=party-token"
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.text.splitlines(),
+            [
+                "#EXTM3U",
+                "#EXT-X-STREAM-INF:BANDWIDTH=2000000",
+                "main.m3u8?MediaSourceId=source&PlaySessionId=session&token=party-token",
+            ],
+        )
+
+    def test_variant_playlist_returns_usable_tokenized_segment_url(self):
+        upstream_playlist = (
+            "#EXTM3U\r\n"
+            "#EXTINF:6.000,\r\n"
+            "hls1/main0.ts?PlaySessionId=session\r\n"
+        )
+        upstream_response = httpx.Response(
+            200,
+            text=upstream_playlist,
+            request=httpx.Request("GET", "http://emby.test/main.m3u8"),
+        )
+
+        with patch("backend.src.routers.hls.httpx.get", return_value=upstream_response):
+            response = _client().get(
+                "/hls/123/main.m3u8?PlaySessionId=session&token=party-token"
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.text.splitlines(),
+            [
+                "#EXTM3U",
+                "#EXTINF:6.000,",
+                "hls1/main0.ts?PlaySessionId=session&token=party-token",
+            ],
+        )
+
+    def test_segment_proxy_returns_playable_transport_stream_bytes(self):
+        upstream_response = httpx.Response(
+            200,
+            content=b"transport-stream-bytes",
+            request=httpx.Request("GET", "http://emby.test/hls1/main0.ts"),
+        )
+
+        with patch("backend.src.routers.hls.httpx.get", return_value=upstream_response):
+            response = _client().get(
+                "/hls/123/hls1/main0.ts?PlaySessionId=session&token=party-token"
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.headers["content-type"].lower(), "video/mp2t")
+        self.assertEqual(response.content, b"transport-stream-bytes")


### PR DESCRIPTION
## What changed

- Rewrite Emby HLS playlists with line-ending-aware token insertion.
- Preserve upstream CRLF/LF formatting and final line termination.
- Add integration tests covering master-playlist rewriting, variant-playlist rewriting, and transport-stream proxying through the public HLS routes.

## Why

Emby emits playlists with CRLF line endings. Splitting only on `\n` left `\r` attached to each media URI. WatchParty then appended its token after that control character, causing HLS.js to parse the token as a separate invalid line. Playback remained buffering at 0:00, no variant playlist or media segments were requested, and Emby eventually marked the session idle.

## Impact

Tokenized HLS variant and segment URLs remain on one valid playlist line, allowing browser playback to progress normally. Public routes and configuration remain unchanged.

## Testing

```text
python -m unittest tests.test_hls_proxy -v

Ran 4 tests in 0.035s
OK
```

- Reproduced failure with a real CRLF Emby master playlist.
- Confirmed WatchParty service restarts healthy after patch.
