### PR TITLE
release: 2.1.1, upstream dependency advisories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,29 @@ Thanks to **[Christian Gillinger](https://github.com/cgillinger)** for the "Refi
 
 ---
 
+## [2.1.1] - 2026-08-05 - Midnight Premiere
+
+A dependency-only security patch. Two upstream advisories are closed, one of which affects the JavaScript that runs in every viewer's browser. No application code changed, no `.env` changes, no migration, nothing to reconfigure. Pull the new image, restart, done.
+
+If you build from source, run `npm ci` in `frontend/` so the updated lockfile is actually installed; `npm install` alone may keep the old resolutions.
+
+### Security
+
+- **`socket.io-parser` 4.2.6 to 4.2.7** closes [CVE-2026-69185](https://github.com/advisories/GHSA-2m8v-j782-fhvr) (**high**), "Zero-attachment Memory Exhaustion", affecting every version from 4.0.0 up to 4.2.7. This is the one that matters most here: the parser is bundled into `socket.io-client` and runs **in the browser**, decoding every frame the server sends, so it sits on the path each viewer uses for the whole session. Watch Party never enabled the attachment features involved, but the parse path is shared, and the fix is a drop-in patch release from the Socket.IO maintainers.
+- **`postcss` 8.5.19 to 8.5.25** closes [CVE-2026-69153](https://github.com/advisories/GHSA-fxqj-rqcc-2cmp) (**medium**), an incomplete fix of [GHSA-6g55-p6wh-862q](https://github.com/advisories/GHSA-6g55-p6wh-862q) in which an attacker-controlled `sourceMappingURL` can read arbitrary `.map` files when `from` is unset. Patched upstream in 8.5.23; this goes to 8.5.25. Despite GitHub classifying it as runtime scope, `postcss` reaches this project only through `vite` and `@vue/compiler-sfc`, both build-time, so the realistic exposure is to whoever runs the build rather than to viewers. Included because there is no reason to ship a known-vulnerable build toolchain.
+
+Both are transitive dependencies. `package.json` is unchanged; the patched versions already sit inside its existing ranges, so only `frontend/package-lock.json` moved. `npm audit` reports zero vulnerabilities on the result.
+
+### Technical details
+
+Neither advisory was reachable through anything Watch Party calls directly, which is why this is a patch and not an emergency. The `socket.io-parser` bump is the substantive one purely because of where it executes: it ships to the client, so leaving it unpatched means shipping known-vulnerable JavaScript to every viewer regardless of whether this application exercises the affected code path.
+
+Both bumps arrived through Dependabot, as [#54](https://github.com/Oratorian/emby-watchparty/pull/54) and [#55](https://github.com/Oratorian/emby-watchparty/pull/55), and this release is the version bump and changelog that publish them.
+
+One incidental detail worth recording, since it will show up in a lockfile diff and looks alarming out of context: alongside its three-line version change, #54 also removed `"dev": true` from 54 `@esbuild/*` platform binaries, reclassifying them as production dependencies. It does not change the built output, because `vite build` emits the same static assets either way, but it does change what a vulnerability scanner configured to skip dev dependencies will report against this lockfile.
+
+---
+
 ## [2.1.0] - 2026-08-03 - Midnight Premiere
 
 A security release. Two authorization gaps are closed, and because the stricter gating can now refuse requests that used to succeed, the UI gained the banners needed to explain itself instead of leaving you staring at a dead player.
@@ -137,6 +160,7 @@ The full per-beta breakdown of the 2.0 development cycle (beta1 through beta18, 
 
 ## Version History Summary
 
+- **v2.1.1**  (2026-08-05): Security -- upstream advisories in `socket.io-parser` (high, browser-side) and `postcss` (medium, build-time).
 - **v2.1.0**  (2026-08-03): Security -- `/hls` now session-gated with a cookie/token party match, and the Emby admin token moved out of the session cookie.
 - **v2.0.2**  (2026-08-01): HLS token rewriting fixed for CRLF playlists (playback stuck buffering at 0:00) + first HLS proxy tests.
 - **v2.0.1**  (2026-07-14): Democratic playback control (any member can play/pause/seek) + sync-guard fixes.

--- a/backend/src/__init__.py
+++ b/backend/src/__init__.py
@@ -1,8 +1,8 @@
 """
 Emby Watch Party - Source Modules
-Version: 2.1.0
+Version: 2.1.1
 Codename: Midnight Premiere
 """
 
-__version__ = "2.1.0"
+__version__ = "2.1.1"
 __codename__ = "Midnight Premiere"

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "dependencies": {
         "axios": "^1.13.6",
         "hls.js": "^1.6.15",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

Publishes the two Dependabot security bumps already merged as #54 and #55. No application code changed; this is the version bump and changelog that release them.

## Changes Made

- `CHANGELOG.md`: 2.1.1 entry plus the Version History line
- `backend/src/__init__.py`: 2.1.0 -> 2.1.1
- `frontend/package.json` and the lockfile's root self-reference: 2.1.0 -> 2.1.1

Codename stays **Midnight Premiere**, as for the whole 2.x line.

## Type of Change

- [x] Dependencies

## Testing Done

- [x] `vue-tsc --build` clean
- [x] `vite build` clean at 2.1.1
- [x] backend suite green (19 passed)
- [x] `npm audit` reports 0 vulnerabilities

## Notes for review

Only two of the eight `"version": "2.1.0"` strings in `package-lock.json` are the root self-reference; the other six belong to third-party packages that happen to share the number. The edit is scoped to the first two occurrences and asserts afterwards that no dependency version moved. The diff is 2 insertions, 2 deletions.

One incidental detail, recorded in the changelog because it looks alarming in a lockfile diff out of context: alongside its three-line version change, #54 also stripped `"dev": true` from 54 `@esbuild/*` platform binaries. It does not change the built output, but it does change what a scanner configured to skip dev dependencies reports.

## Related Issues

Closes the two Dependabot alerts:
- socket.io-parser, CVE-2026-69185 (high)
- postcss, CVE-2026-69153 (medium)