### PR TITLE
Improve 2.1.x to 3.0 migration diagnostics

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,10 @@
 # session, REQUIRE_LOGIN, FORCE_TRANSCODE, etc.) are managed via the
 # Admin Panel at /admin and persisted to config.json. A restart is
 # only required for changes to the values below.
+#
+# Upgrading from 2.1.x? Back up this file, Compose/container configuration,
+# config.json, data/, images/avatars/, and volume mappings. Then run the
+# read-only preflight documented in docs/Migration-HowTo.md before starting 3.0.
 
 # ============== Application ==============
 # Network bind. 0.0.0.0 listens on all interfaces (typical for Docker).
@@ -15,7 +19,8 @@ WATCH_PARTY_PORT=5000
 # settings. Keep `development` for local plain-HTTP use.
 APP_ENV=development
 
-# Session cookie lifetime in seconds (default: 24h).
+# Session cookie lifetime in seconds (default: 24h). Use 1209600 to retain the
+# old 2.1.x 14-day cookie behavior.
 SESSION_EXPIRY=86400
 
 # Base URL prefix for reverse-proxy deployments behind a subpath.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,11 @@ Two lessons from that pass are worth stating, because they shaped how the rest w
 
 Unlike every 2.x release, this one needs reading before you upgrade, and [`docs/Migration-HowTo.md`](docs/Migration-HowTo.md) now covers the 2.1.x → 3.0 path.
 
-Rate limiting becomes **enforced**, using the values already sitting in your `config.json`, values nobody has tuned because they previously did nothing. This is the change most likely to be noticed, and it is silent when it bites: a third person tries to join movie night and simply cannot, with nothing in the interface naming a limit.
+Rate limiting becomes **enforced**, using the values already sitting in your `config.json`, values nobody has tuned because they previously did nothing. This is the change most likely to be noticed. Blocked HTTP actions, socket connections, session binding, chat, login, and avatar recovery now name the limit and show a safe retry delay; rejected chat text is restored for manual resend. Progress telemetry remains silently coalesced because the latest visible party time is still committed.
+
+A read-only `python -m backend.migration_preflight` command now inventories the effective 2.1.x inputs without writing files or printing secrets. It reports proxy/HLS actions, inherited rate limits, session-expiry behavior, runtime versions, one-worker requirements, preserved paths, health/readiness expectations, and manual backup/rollback work. The migration guide includes Compose, appliance, plain Docker, source, and Windows invocations.
+
+The named `npm run test:playback-gate` acceptance command now drives authenticated master/media playlists, segments and byte ranges; pause/resume and bidirectional seeking; audio/subtitle selection; reconnect, host reload, and session-bind retry; cross-party denial; plus the iPhone WebKit native-HLS selection path against fake Emby.
 
 `BEHIND_PROXY` is the one genuinely new setting, and production refuses to boot until you declare it, `true` or `false`. That is deliberate, because guessing wrong is silent: rate limiting keys on the address a connection arrives from, and behind a reverse proxy that address is the proxy, identical for every viewer, so all of them share one bucket. Setting it `true` makes `TRUSTED_PROXY_CIDRS` mandatory. If a forwarding header turns up on a deployment that declared itself direct, the server now says so in the log, once, rather than silently discarding it.
 

--- a/README.md
+++ b/README.md
@@ -172,6 +172,20 @@ Emby Watch Party works best with the following browsers:
 
 ### Docker installation
 
+Upgrading from 2.1.x is not a drop-in image swap. Back up `.env`, the effective
+Compose/container configuration, `config.json`, `data/`, `images/avatars/`, and
+all volume mappings, then read [the 3.0 migration guide](docs/Migration-HowTo.md).
+With the 3.0 Compose service configured, run its read-only preflight before
+starting the upgrade:
+
+```bash
+docker compose run --rm --no-deps emby-watchparty python -m backend.migration_preflight
+```
+
+Keep the full 2.1.x backup and previous image until health, readiness, login,
+HLS, seeking, subtitles, reconnects, and rate-limit messages pass validation.
+Rollback restores that complete backup and image; do not delete legacy data.
+
 The pre-built multi-arch image is published to GitHub Container Registry:
 
 ```bash

--- a/backend/app.py
+++ b/backend/app.py
@@ -6,7 +6,7 @@ import json
 import logging
 import secrets
 import sys
-from contextlib import AsyncExitStack, asynccontextmanager, suppress
+from contextlib import AsyncExitStack, asynccontextmanager
 from pathlib import Path
 
 import httpx
@@ -163,6 +163,16 @@ async def _shutdown_runtime(
     )
 
 
+def _remove_stale_setup_artifacts(root: Path, logger) -> None:
+    """Remove obsolete setup files only after runtime startup succeeds."""
+    for name in ("bootstrap.json", "setup-token"):
+        path = root / "data" / name
+        try:
+            path.unlink(missing_ok=True)
+        except OSError as exc:
+            logger.warning("Could not remove obsolete setup artifact %s: %s", name, exc)
+
+
 def _setup_logging(config: Config):
     from rsyslog_logger import setup_logger
 
@@ -273,6 +283,8 @@ async def lifespan(application: FastAPI):
         if application.state.enable_update_check:
             await check_for_updates(http_client, logger)
 
+        _remove_stale_setup_artifacts(root, logger)
+
         yield
 
 
@@ -349,12 +361,6 @@ def create_app(
         resolved_config.validate_for_startup()
     except ValueError:
         return _create_setup_app(resolved_config, resolved_root)
-    # Left behind by 3.0 development builds that had an interactive setup
-    # flow. Configuration is environment-only now, so neither file is
-    # read; remove them rather than leave a stale credential on disk.
-    for stale in ("bootstrap.json", "setup-token"):
-        with suppress(OSError):
-            (resolved_root / "data" / stale).unlink()
     prefix = resolved_config.APP_PREFIX
     session_secret = resolved_config.SESSION_SECRET or secrets.token_hex(32)
     origins: str | list[str]

--- a/backend/migration_preflight.py
+++ b/backend/migration_preflight.py
@@ -1,0 +1,239 @@
+"""Read-only 2.1.x to 3.0 migration preflight."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+
+_BOOT_FIELDS = {
+    "BEHIND_PROXY",
+    "TRUSTED_PROXY_CIDRS",
+    "ENABLE_HLS_TOKEN_VALIDATION",
+    "SESSION_EXPIRY",
+}
+_ENV_KEY = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+
+
+class _Report:
+    def __init__(self) -> None:
+        self.lines: list[str] = []
+        self.incomplete = False
+
+    def error(self, message: str, *, incomplete: bool = False) -> None:
+        self.lines.append(f"ERROR: {message}")
+        self.incomplete = self.incomplete or incomplete
+
+    def action(self, message: str) -> None:
+        self.lines.append(f"REQUIRED ACTION: {message}")
+
+    def info(self, message: str) -> None:
+        self.lines.append(f"INFO: {message}")
+
+
+def _read_dotenv(path: Path, report: _Report) -> dict[str, str]:
+    if not path.exists():
+        report.info(".env not found; preserve the deployment's actual environment source")
+        return {}
+    if not path.is_file():
+        report.error(".env is not a regular file", incomplete=True)
+        return {}
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        report.error(".env could not be read", incomplete=True)
+        return {}
+
+    values: dict[str, str] = {}
+    for number, original in enumerate(lines, start=1):
+        line = original.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("export "):
+            line = line[7:].lstrip()
+        if "=" not in line:
+            report.error(f".env line {number} is malformed", incomplete=True)
+            continue
+        key, value = line.split("=", 1)
+        key = key.strip()
+        if not _ENV_KEY.fullmatch(key):
+            report.error(f".env line {number} has an invalid variable name", incomplete=True)
+            continue
+        if key not in _BOOT_FIELDS:
+            continue
+        value = value.strip()
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+            value = value[1:-1]
+        values[key] = value
+    return values
+
+
+def _read_legacy(path: Path, report: _Report) -> dict[str, object]:
+    if not path.exists():
+        report.info("config.json not found; legacy runtime settings will use defaults")
+        return {}
+    if not path.is_file():
+        report.error("config.json is not a regular file", incomplete=True)
+        return {}
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        report.error("config.json is not valid JSON", incomplete=True)
+        return {}
+    except OSError:
+        report.error("config.json could not be read", incomplete=True)
+        return {}
+    if not isinstance(value, dict):
+        report.error("config.json must contain a JSON object", incomplete=True)
+        return {}
+    return value
+
+
+def _boolean(value: object) -> bool | None:
+    if isinstance(value, bool):
+        return value
+    normalized = str(value).strip().lower()
+    if normalized in {"true", "1", "yes"}:
+        return True
+    if normalized in {"false", "0", "no"}:
+        return False
+    return None
+
+
+def _effective(
+    name: str,
+    environ: Mapping[str, str],
+    dotenv: Mapping[str, str],
+    *,
+    legacy: object | None = None,
+    default: object,
+) -> tuple[object, str]:
+    if name in environ:
+        return environ[name], "process environment"
+    if name in dotenv:
+        return dotenv[name], ".env"
+    if legacy is not None:
+        return legacy, "legacy config.json"
+    return default, "default"
+
+
+def run_preflight(
+    root: Path,
+    *,
+    target: str = "production",
+    deployment: str = "docker",
+    environ: Mapping[str, str] | None = None,
+) -> tuple[int, str]:
+    """Inspect migration inputs without invoking mutating config loaders."""
+    report = _Report()
+    root = root.resolve()
+    env = dict(os.environ if environ is None else environ)
+    dotenv = _read_dotenv(root / ".env", report)
+    legacy = _read_legacy(root / "config.json", report)
+
+    behind_raw, behind_source = _effective("BEHIND_PROXY", env, dotenv, default="", legacy=None)
+    behind = _boolean(behind_raw) if behind_source != "default" else None
+    if behind is None:
+        if behind_source == "default":
+            report.action("Set BEHIND_PROXY=true or BEHIND_PROXY=false before starting 3.0")
+        else:
+            report.error("BEHIND_PROXY must be true or false")
+    else:
+        report.info(f"BEHIND_PROXY={'true' if behind else 'false'} ({behind_source})")
+
+    cidrs, cidr_source = _effective("TRUSTED_PROXY_CIDRS", env, dotenv, default="", legacy=None)
+    if behind and not str(cidrs).strip():
+        report.action(
+            "Set TRUSTED_PROXY_CIDRS to the proxy network, for example "
+            "TRUSTED_PROXY_CIDRS=172.16.0.0/12"
+        )
+    elif str(cidrs).strip():
+        report.info(f"TRUSTED_PROXY_CIDRS is declared ({cidr_source})")
+    elif behind is False:
+        report.info("TRUSTED_PROXY_CIDRS is empty, correct for BEHIND_PROXY=false")
+
+    legacy_hls = legacy.get("ENABLE_HLS_TOKEN_VALIDATION")
+    hls_raw, hls_source = _effective(
+        "ENABLE_HLS_TOKEN_VALIDATION",
+        env,
+        dotenv,
+        legacy=legacy_hls,
+        default=True,
+    )
+    hls = _boolean(hls_raw)
+    if hls is None:
+        report.error("ENABLE_HLS_TOKEN_VALIDATION must be true or false")
+    else:
+        report.info(f"ENABLE_HLS_TOKEN_VALIDATION={'true' if hls else 'false'} ({hls_source})")
+        if target == "production" and not hls:
+            report.action(
+                "Set ENABLE_HLS_TOKEN_VALIDATION=true in the environment; "
+                "production otherwise fails closed"
+            )
+
+    expiry_raw, expiry_source = _effective(
+        "SESSION_EXPIRY", env, dotenv, default="86400", legacy=None
+    )
+    try:
+        expiry = int(str(expiry_raw))
+    except ValueError:
+        report.error("SESSION_EXPIRY must be an integer number of seconds")
+    else:
+        report.info(f"SESSION_EXPIRY={expiry} ({expiry_source})")
+        if expiry != 1_209_600:
+            report.info("Set SESSION_EXPIRY=1209600 to retain the old 14-day cookie behavior")
+
+    if deployment == "docker":
+        report.info("Docker image supplies Python 3.12 and its frontend is built with Node 24")
+    else:
+        report.info("Source deployment requires Python >=3.12,<3.13 and Node >=20.19")
+
+    for relative, label in (
+        (".env", "environment file"),
+        ("config.json", "legacy runtime configuration"),
+        ("data", "data directory"),
+        ("images/avatars", "avatar directory"),
+    ):
+        state = "found" if (root / relative).exists() else "not found here"
+        report.info(f"Preserve {relative} ({label}; {state}) and its volume mapping")
+    report.action(
+        "Confirm a full backup of .env, Compose configuration, config.json, data, avatars, "
+        "and volume mappings before upgrade"
+    )
+    report.info("Keep the 2.1.x image and configuration until real playback validation passes")
+    report.info("Healthy 3.0: /api/health returns 200 ok and /api/ready returns 200")
+    report.info(
+        "Invalid production config: /api/health returns 200 setup_required, "
+        "/api/ready returns 503, and other routes remain unavailable"
+    )
+    report.action(
+        "Prepare rollback by restoring the full backup and previous image/configuration; "
+        "do not delete legacy files"
+    )
+
+    return (1 if report.incomplete else 0), "\n".join(report.lines) + "\n"
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--target", choices=("production", "development"), default="production")
+    parser.add_argument("--deployment", choices=("docker", "source"), default="docker")
+    args = parser.parse_args(argv)
+    code, output = run_preflight(
+        args.root,
+        target=args.target,
+        deployment=args.deployment,
+    )
+    print(output, end="")
+    return code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/migration_preflight.py
+++ b/backend/migration_preflight.py
@@ -6,6 +6,9 @@ import argparse
 import json
 import os
 import re
+import shutil
+import subprocess
+import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -28,6 +31,7 @@ _RATE_DEFAULTS = {
     "RATE_LIMIT_CHAT": "5 per 3 seconds",
     "RATE_LIMIT_SOCKET_CONNECTIONS": "30 per minute",
 }
+_WORKER_FIELDS = ("WEB_CONCURRENCY", "UVICORN_WORKERS", "WORKERS")
 _ENV_KEY = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
 
 
@@ -75,7 +79,7 @@ def _read_dotenv(path: Path, report: _Report) -> dict[str, str]:
         if not _ENV_KEY.fullmatch(key):
             report.error(f".env line {number} has an invalid variable name", incomplete=True)
             continue
-        if key not in _BOOT_FIELDS:
+        if key not in _BOOT_FIELDS and key not in _WORKER_FIELDS:
             continue
         value = value.strip()
         if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
@@ -133,12 +137,33 @@ def _effective(
     return default, "default"
 
 
+def _node_version() -> tuple[int, ...] | None:
+    executable = shutil.which("node")
+    if executable is None:
+        return None
+    try:
+        result = subprocess.run(  # noqa: S603 - executable resolved with shutil.which
+            [executable, "--version"],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    match = re.fullmatch(r"v?(\d+)\.(\d+)\.(\d+)\s*", result.stdout)
+    return tuple(map(int, match.groups())) if match else None
+
+
 def run_preflight(
     root: Path,
     *,
     target: str = "production",
     deployment: str = "docker",
     environ: Mapping[str, str] | None = None,
+    platform_name: str | None = None,
+    python_version: Sequence[int] | None = None,
+    node_version: Sequence[int] | None = None,
 ) -> tuple[int, str]:
     """Inspect migration inputs without invoking mutating config loaders."""
     report = _Report()
@@ -212,10 +237,42 @@ def run_preflight(
             continue
         report.info(f"{name}={raw} ({source}); this limit is enforced in 3.0")
 
+    worker_declared = False
+    worker_valid = True
+    for name in _WORKER_FIELDS:
+        raw, source = _effective(name, env, dotenv, default="", legacy=None)
+        if source == "default" or not str(raw).strip():
+            continue
+        worker_declared = True
+        try:
+            valid = int(str(raw)) == 1
+        except ValueError:
+            valid = False
+        worker_valid = worker_valid and valid
+    if not worker_declared:
+        report.info("No worker override found; 3.0 supports exactly one application worker")
+    elif worker_valid:
+        report.info("Application worker count is 1")
+    else:
+        report.action("Run exactly one application worker; set worker count to 1")
+
+    active_platform = (platform_name or sys.platform).lower()
+    if active_platform.startswith("win"):
+        report.info("Windows support is best effort; Docker/Linux is recommended")
+
+    active_python = tuple(python_version or sys.version_info[:3])
     if deployment == "docker":
         report.info("Docker image supplies Python 3.12 and its frontend is built with Node 24")
     else:
-        report.info("Source deployment requires Python >=3.12,<3.13 and Node >=20.19")
+        if not ((3, 12) <= active_python[:2] < (3, 13)):
+            report.action("Use Python >=3.12,<3.13 and recreate the virtual environment")
+        else:
+            report.info(f"Python {'.'.join(map(str, active_python[:3]))} meets >=3.12,<3.13")
+        active_node = tuple(node_version) if node_version is not None else _node_version()
+        if active_node is None or active_node[:2] < (20, 19):
+            report.action("Use Node >=20.19 when building the frontend from source")
+        else:
+            report.info(f"Node {'.'.join(map(str, active_node[:3]))} meets >=20.19")
 
     for relative, label in (
         (".env", "environment file"),

--- a/backend/migration_preflight.py
+++ b/backend/migration_preflight.py
@@ -9,6 +9,8 @@ import re
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from backend.src.rate_limit import parse_rate
+
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
 
@@ -17,6 +19,14 @@ _BOOT_FIELDS = {
     "TRUSTED_PROXY_CIDRS",
     "ENABLE_HLS_TOKEN_VALIDATION",
     "SESSION_EXPIRY",
+}
+_RATE_DEFAULTS = {
+    "RATE_LIMIT_PARTY_CREATION": "5 per hour",
+    "RATE_LIMIT_API_CALLS": "1000 per minute",
+    "RATE_LIMIT_LOGIN": "10 per 15 minutes",
+    "RATE_LIMIT_AVATAR_RECOVERY": "10 per hour",
+    "RATE_LIMIT_CHAT": "5 per 3 seconds",
+    "RATE_LIMIT_SOCKET_CONNECTIONS": "30 per minute",
 }
 _ENV_KEY = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
 
@@ -188,6 +198,19 @@ def run_preflight(
         report.info(f"SESSION_EXPIRY={expiry} ({expiry_source})")
         if expiry != 1_209_600:
             report.info("Set SESSION_EXPIRY=1209600 to retain the old 14-day cookie behavior")
+
+    for name, default in _RATE_DEFAULTS.items():
+        raw = legacy.get(name, default)
+        source = "legacy config.json" if name in legacy else "default"
+        if not isinstance(raw, str):
+            report.error(f"{name} must be a rate string")
+            continue
+        try:
+            parse_rate(raw)
+        except ValueError:
+            report.error(f"{name} has a malformed legacy value")
+            continue
+        report.info(f"{name}={raw} ({source}); this limit is enforced in 3.0")
 
     if deployment == "docker":
         report.info("Docker image supplies Python 3.12 and its frontend is built with Node 24")

--- a/backend/socket-events.schema.json
+++ b/backend/socket-events.schema.json
@@ -72,6 +72,18 @@
         "party_id": {
           "title": "Party Id",
           "type": "string"
+        },
+        "request_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Request Id"
         }
       },
       "required": [
@@ -1390,6 +1402,43 @@
         "time"
       ],
       "title": "TimedOutbound",
+      "type": "object"
+    },
+    "rate_limited": {
+      "additionalProperties": false,
+      "properties": {
+        "action": {
+          "const": "chat",
+          "title": "Action",
+          "type": "string"
+        },
+        "message": {
+          "title": "Message",
+          "type": "string"
+        },
+        "request_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Request Id"
+        },
+        "retry_after": {
+          "title": "Retry After",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "message",
+        "action",
+        "retry_after"
+      ],
+      "title": "RateLimitedOutbound",
       "type": "object"
     },
     "ready_check_update": {

--- a/backend/src/rate_limit.py
+++ b/backend/src/rate_limit.py
@@ -44,6 +44,20 @@ class RateLimitDecision:
     retry_after: int = 0
 
 
+def rate_limit_response(action: str, retry_after: int) -> JSONResponse:
+    """Return one safe, typed HTTP 429 contract."""
+    detail = f"Too many {action}. Try again in {retry_after} seconds."
+    return JSONResponse(
+        {
+            "detail": detail,
+            "code": "rate_limited",
+            "retry_after": retry_after,
+        },
+        status_code=429,
+        headers={"Retry-After": str(retry_after)},
+    )
+
+
 class SlidingWindowRateLimiter:
     # Reclaiming expired buckets is a memory concern, not a correctness one.
     # `check` already discards every timestamp older than the window from the
@@ -142,6 +156,11 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
             return await call_next(request)
 
         is_party_create = path == f"{api_root}/party/create" and request.method == "POST"
+        is_party_join = (
+            request.method == "POST"
+            and path.startswith(f"{api_root}/party/")
+            and path.endswith("/join")
+        )
         spec = config.RATE_LIMIT_PARTY_CREATION if is_party_create else config.RATE_LIMIT_API_CALLS
         try:
             limit, window = parse_rate(spec)
@@ -152,9 +171,11 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         scope = "party-create" if is_party_create else "api"
         decision = request.app.state.rate_limiter.check(f"{scope}:{client_ip}", limit, window)
         if not decision.allowed:
-            return JSONResponse(
-                {"detail": "Rate limit exceeded"},
-                status_code=429,
-                headers={"Retry-After": str(decision.retry_after)},
-            )
+            if is_party_create:
+                action = "party creation attempts"
+            elif is_party_join:
+                action = "party join attempts"
+            else:
+                action = "requests"
+            return rate_limit_response(action, decision.retry_after)
         return await call_next(request)

--- a/backend/src/routers/admin.py
+++ b/backend/src/routers/admin.py
@@ -13,7 +13,6 @@ Two paths in:
 """
 
 from fastapi import APIRouter, Depends, Request
-from fastapi.responses import JSONResponse
 
 from backend.src.client_ip import request_client_ip
 from backend.src.dependencies import (
@@ -28,7 +27,7 @@ from backend.src.dependencies import (
     scrub_legacy_admin_session,
 )
 from backend.src.log_levels import apply_log_levels
-from backend.src.rate_limit import parse_rate
+from backend.src.rate_limit import parse_rate, rate_limit_response
 from backend.src.schemas import (
     AdminLoginRequest,
     AdminLoginResponse,
@@ -78,16 +77,7 @@ async def admin_login(
             logger.warning(
                 f"Admin login rate-limited for IP {ip} (retry in {decision.retry_after}s)"
             )
-            return JSONResponse(
-                {
-                    "success": False,
-                    "message": (
-                        f"Too many login attempts. Try again in {decision.retry_after} seconds."
-                    ),
-                },
-                status_code=429,
-                headers={"Retry-After": str(decision.retry_after)},
-            )
+            return rate_limit_response("login attempts", decision.retry_after)
     auth = await emby_client.authenticate(body.username, body.password)
     if not auth:
         return {"success": False, "message": "Invalid credentials"}

--- a/backend/src/routers/avatar.py
+++ b/backend/src/routers/avatar.py
@@ -16,7 +16,7 @@ import asyncio
 import contextlib
 from pathlib import Path
 
-from fastapi import APIRouter, Depends, File, HTTPException, Request, UploadFile
+from fastapi import APIRouter, Depends, File, Request, UploadFile
 from fastapi.responses import Response
 from pydantic import BaseModel
 
@@ -30,7 +30,7 @@ from backend.src.dependencies import (
     get_logger,
     get_party_manager,
 )
-from backend.src.rate_limit import parse_rate
+from backend.src.rate_limit import parse_rate, rate_limit_response
 
 router = APIRouter(prefix="/api/avatar", tags=["avatar"])
 
@@ -166,11 +166,7 @@ def recover(
         decision = request.app.state.rate_limiter.check(f"avatar-recover:{ip}", limit, window)
         if not decision.allowed:
             logger.warning(f"Avatar recover rate-limited for ip={ip}")
-            raise HTTPException(
-                status_code=429,
-                detail="Too many recovery attempts. Try again later.",
-                headers={"Retry-After": str(decision.retry_after)},
-            )
+            return rate_limit_response("avatar recovery attempts", decision.retry_after)
 
     code = (body.code or "").strip().lower()
     if not code:

--- a/backend/src/socket_handlers/chat.py
+++ b/backend/src/socket_handlers/chat.py
@@ -38,6 +38,19 @@ def register(ctx):
             decision = rate_limiter.check(f"chat:{sid}", limit, window)
             if not decision.allowed:
                 logger.debug(f"Chat message dropped: sid={sid} rate-limited in {party_id}")
+                await sio.emit(
+                    "rate_limited",
+                    {
+                        "action": "chat",
+                        "message": (
+                            "Message not sent: chat limit reached. "
+                            f"Try again in {decision.retry_after} seconds."
+                        ),
+                        "retry_after": decision.retry_after,
+                        "request_id": data.get("request_id"),
+                    },
+                    to=sid,
+                )
                 return
             username = party.username_for_sid(sid)
             # Look up the sender's persistent avatar identity so the

--- a/backend/src/socket_handlers/connection.py
+++ b/backend/src/socket_handlers/connection.py
@@ -211,8 +211,7 @@ def register(ctx):
             decision = rate_limiter.check(f"socket-connect:{client_ip}", limit, window)
             if not decision.allowed:
                 message = (
-                    "Too many connection attempts. "
-                    f"Try again in {decision.retry_after} seconds."
+                    f"Too many connection attempts. Try again in {decision.retry_after} seconds."
                 )
                 raise SocketConnectionRefusedError(
                     message,

--- a/backend/src/socket_handlers/connection.py
+++ b/backend/src/socket_handlers/connection.py
@@ -210,7 +210,14 @@ def register(ctx):
             limit, window = parse_rate(config.RATE_LIMIT_SOCKET_CONNECTIONS)
             decision = rate_limiter.check(f"socket-connect:{client_ip}", limit, window)
             if not decision.allowed:
-                raise SocketConnectionRefusedError("rate_limited")
+                message = (
+                    "Too many connection attempts. "
+                    f"Try again in {decision.retry_after} seconds."
+                )
+                raise SocketConnectionRefusedError(
+                    message,
+                    {"code": "rate_limited", "retry_after": decision.retry_after},
+                )
         # The connect step is best-effort. We log what the cookie looks
         # like for diagnostics but never refuse the socket: party-bound
         # routing happens via the `join_party` event which carries an

--- a/backend/src/socket_protocol.py
+++ b/backend/src/socket_protocol.py
@@ -46,6 +46,7 @@ class UpdateAvatarPayload(PartyPayload):
 
 class ChatPayload(PartyPayload):
     message: str
+    request_id: str | None = None
 
 
 class ToggleLibraryPayload(PartyPayload):
@@ -212,6 +213,12 @@ class ChatOutbound(OutboundPayload):
     timestamp: str
 
 
+class RateLimitedOutbound(MessageOutbound):
+    action: Literal["chat"]
+    retry_after: int
+    request_id: str | None = None
+
+
 class ToggleLibraryOutbound(OutboundPayload):
     show: bool
 
@@ -301,6 +308,7 @@ OUTBOUND_MODELS: dict[str, type[OutboundPayload]] = {
     "force_pause_before_seek": TimedOutbound,
     "drift_correction": TimedOutbound,
     "chat_message": ChatOutbound,
+    "rate_limited": RateLimitedOutbound,
     "toggle_library": ToggleLibraryOutbound,
     "host_changed": HostOutbound,
     "host_left": HostOutbound,

--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -10,6 +10,9 @@
 #
 # `version:` is omitted intentionally -- modern Docker Compose v2
 # ignores it and warns on its presence.
+#
+# 2.1.x upgrade preflight (read-only; back up every listed mount first):
+# docker compose run --rm --no-deps emby-watchparty python -m backend.migration_preflight
 
 services:
   emby-watchparty:
@@ -103,7 +106,7 @@ services:
       # fails to write its settings.
       - ./config.json:/app/config.json
 
-    # The baked /api/health probe is a liveness check. Setup mode returns
+    # The baked /api/health probe is a liveness check. Invalid configuration returns
     # HTTP 200 with status=setup_required so Compose does not restart-loop.
     # Use /api/ready instead if dependants must wait for normal app service.
     # Uncomment to tighten the liveness cadence:

--- a/docs/Migration-HowTo.md
+++ b/docs/Migration-HowTo.md
@@ -1,8 +1,8 @@
 # Migration: 2.1.x → 3.0
 
 This guide covers the 3.0 beta line built from `3.0-dev`. Read it before
-upgrading a stable deployment. Keep 2.1.x available for rollback until the
-new setup has completed a real playback test.
+upgrading a stable deployment. Keep the complete 2.1.x configuration and image
+available for rollback until 3.0 has completed a real playback test.
 
 Users upgrading from 1.x should first follow the migration guide shipped with
 the latest 2.1.x release, then return here.
@@ -79,11 +79,62 @@ days. See the section on it below.
 No migration should delete the old `.env`, `config.json`, `data/`, or avatar
 directories before the new version has started successfully.
 
+## Run the read-only preflight
+
+Back up `.env`, the Compose/container definition, `config.json`, `data/`,
+`images/avatars/`, and every volume mapping first. Then run the 3.0 image's
+preflight against the same environment and mounts the application will use:
+
+```bash
+docker compose run --rm --no-deps emby-watchparty python -m backend.migration_preflight
+```
+
+The command only reads migration inputs. It does not load the normal mutating
+configuration path, write settings, move malformed files, clean stale setup
+artifacts, or print session secrets, API keys, tokens, credentials, or cookies.
+It exits `0` when inspection completed, even when work remains. It exits `1`
+only when an input could not be inspected, such as malformed JSON or a path
+that is a directory instead of a file.
+
+Interpret every line by its prefix:
+
+- `ERROR` means an input was malformed or unreadable. Fix it before relying on
+  the rest of the report.
+- `REQUIRED ACTION` is an operator step that must be completed or explicitly
+  confirmed. This includes backup and rollback readiness; exit `0` does not
+  certify that a backup exists.
+- `INFO` records an effective setting, its safe source, a preserved path, or a
+  behavior change to validate.
+
+For a source checkout, include runtime checks:
+
+```bash
+python -m backend.migration_preflight --deployment source
+```
+
+On Windows use `.venv\Scripts\python.exe` in place of `python`. Windows results
+are best effort and recommend Docker/Linux for production. On Unraid, CasaOS,
+Portainer, and TrueNAS, run the same module as a one-shot command using the 3.0
+image, the production container's environment, and the same read-only appdata
+mounts; set the command override to
+`python -m backend.migration_preflight --root /app`. Plain Docker users can use:
+
+```bash
+docker run --rm --env-file .env \
+  -v "$PWD/config.json:/app/config.json:ro" \
+  -v "$PWD/data:/app/data:ro" \
+  -v "$PWD/images/avatars:/app/images/avatars:ro" \
+  IMAGE python -m backend.migration_preflight --root /app
+```
+
+Replace `IMAGE` with the exact 3.0 image being tested. Never paste secret values
+into a support request.
+
 ## Docker Compose upgrade
 
 1. Stop the watch-party container. Emby can remain online.
-2. Back up `.env`, `docker-compose.yml`, `config.json`, `data/`, and
-   `images/avatars/`.
+2. Back up `.env`, the effective Compose configuration, `config.json`, `data/`,
+   `images/avatars/`, and the volume mappings. Keep the old image reference.
 3. Keep these mounts:
 
    ```yaml
@@ -94,8 +145,9 @@ directories before the new version has started successfully.
    ```
 
    Create the host-side `config.json` as a file before starting Compose.
-4. Pull the chosen 3.0 beta image or build from `3.0-dev`.
-5. Start the container and inspect its logs.
+4. Run the preflight and resolve every required production action.
+5. Pull the chosen 3.0 beta image or build from `3.0-dev`.
+6. Start the container and inspect its logs.
 
 The baked `/api/health` probe is liveness only. Setup mode intentionally
 returns HTTP 200 with `status: setup_required` so Docker does not restart-loop.
@@ -146,10 +198,13 @@ Precedence is:
 
 1. Process environment
 2. Untracked `.env`
-3. Code defaults
+3. Supported legacy persisted value (`ENABLE_HLS_TOKEN_VALIDATION` only)
+4. Code defaults
 
 Process-environment and `.env` are one explicit-operator tier, with process
 values winning. Reading `.env` does not mutate the running process environment.
+Runtime settings such as rate limits continue to come from `config.json`; the
+preflight reports each effective value and its source because 3.0 enforces it.
 
 ## Required production boot values
 
@@ -175,9 +230,9 @@ guessing wrong is silent and expensive.
 Rate limiting keys on the address a connection arrives from. Behind a reverse
 proxy that address is the **proxy**, identical for every viewer, so all of them
 share one bucket. With the shipped defaults that means 5 party creations per
-hour and 30 socket connects per minute for the entire deployment, and the person
-affected simply sees it not work, with nothing in the UI naming a limit. 2.x was
-unaffected because none of these limits were enforced.
+hour and 30 socket connects per minute for the entire deployment. 2.x was
+unaffected because none of these limits were enforced. 3.0 now names a blocked
+action and its safe retry delay in the affected form or connection banner.
 
 - **`BEHIND_PROXY=true`** makes `TRUSTED_PROXY_CIDRS` mandatory. Setting it true
   with an empty CIDR list is refused at boot, in every environment, because it
@@ -305,19 +360,31 @@ share them.
 
 Before directing users to 3.0:
 
-- `/api/health` reports `ok`, not `setup_required`.
-- `/api/ready` succeeds and reaches Emby.
-- Administrator login and logout work.
+- `curl -i http://HOST:PORT/api/health` returns `200` with `status: ok`, not
+  `setup_required`.
+- `curl -i http://HOST:PORT/api/ready` returns `200` and reaches Emby.
+- Administrator login, renewed admin controls, and logout work.
 - Create two separate parties and verify an HLS URL from one cannot be used
   with the other party's cookie.
-- Test master playlist, variant playlist, segment playback, seeking, audio,
-  subtitles, and an alternate media version.
-- Refresh and reconnect a participant using the same browser identity.
+- Test the master playlist, media playlist, segment playback, byte ranges,
+  pause/resume, forward and backward seeking, audio, subtitles, and an
+  alternate media version.
+- Disconnect/reconnect a participant, reload the host page, and confirm both
+  identities resume the same party and receive a fresh playable stream.
+- In a staging party, temporarily use a low rate limit and confirm create,
+  join/session binding, Socket.IO reconnect, chat, login, and avatar recovery
+  show the backend message and retry delay. Restore the production value.
 - Confirm logs do not contain Emby tokens, session secrets, or setup tokens.
 - Confirm `/hls` and health request logs remain at DEBUG volume.
 
+Keep the old configuration and image until every playback check passes. The
+automated fake-Emby gate is `cd frontend && npm run test:playback-gate`; it does
+not replace testing real media, a physical iPhone/iPad, and the actual proxy.
+
 ## Rollback
 
-Stop 3.0, restore the backed-up 2.1.x image and configuration, then start the
-old container. Do not point 2.1.x at files you allowed 3.0 to modify unless you
-have verified their compatibility; restoring the backup is safer.
+Stop 3.0. Restore the full backup: the previous image reference, `.env`,
+Compose/container definition, `config.json`, data, avatars, and volume mappings.
+Then start the old container and validate its health. Do not point 2.1.x at
+files 3.0 used or delete legacy data; restoring the complete backup is the
+supported rollback.

--- a/frontend/e2e/fake-emby.spec.ts
+++ b/frontend/e2e/fake-emby.spec.ts
@@ -1,5 +1,30 @@
 import { expect, test } from '@playwright/test'
 
+test('party host login shows backend rate-limit detail', async ({ page }) => {
+  await page.goto('/')
+  await page.getByRole('button', { name: 'Create Party', exact: true }).click()
+  await page.getByPlaceholder('Your name (optional)').fill('Alice')
+  await page.getByRole('button', { name: 'Join', exact: true }).click()
+  await page.getByRole('main').getByRole(
+    'button', { name: 'Login to Become Host', exact: true },
+  ).click()
+  await page.getByPlaceholder('Emby username').fill('Alice')
+  await page.getByPlaceholder('Emby password').fill('password')
+  await page.route('**/api/auth/login', (route) => route.fulfill({
+    status: 429,
+    headers: { 'content-type': 'application/json', 'retry-after': '7' },
+    body: JSON.stringify({
+      detail: 'Too many login attempts. Try again in 7 seconds.',
+      code: 'rate_limited',
+      retry_after: 7,
+    }),
+  }))
+
+  await page.getByRole('button', { name: 'Become Host', exact: true }).click()
+
+  await expect(page.getByText('Too many login attempts. Try again in 7 seconds.')).toBeVisible()
+})
+
 test('host authenticates and browses the fake Emby library', async ({ page }) => {
   await page.goto('/')
   await page.getByRole('button', { name: 'Create Party', exact: true }).click()

--- a/frontend/e2e/ios.spec.ts
+++ b/frontend/e2e/ios.spec.ts
@@ -22,7 +22,7 @@ test('iOS viewport supports safe areas and party controls remain usable', async 
   await expect(page.getByTitle('Close chat')).toBeVisible()
 })
 
-test('iPhone WebKit selects native HLS from fake Emby', async ({ page }) => {
+test('@playback-gate iPhone WebKit selects native HLS from fake Emby', async ({ page }) => {
   await page.goto('/')
   await page.getByRole('button', { name: 'Create Party', exact: true }).tap()
   await page.getByPlaceholder('Your name (optional)').fill('Alice')

--- a/frontend/e2e/playback-gate.spec.ts
+++ b/frontend/e2e/playback-gate.spec.ts
@@ -1,0 +1,173 @@
+import { expect, test, type APIResponse, type Page } from '@playwright/test'
+
+function mediaUri(playlist: string): string {
+  const value = playlist.split(/\r?\n/).find((line) => line && !line.startsWith('#'))
+  if (!value) throw new Error('Playlist contained no media URI')
+  return value
+}
+
+async function createAndJoin(page: Page, name: string): Promise<string> {
+  await page.goto('/')
+  await page.getByRole('button', { name: 'Create Party', exact: true }).click()
+  await expect(page).toHaveURL(/\/party\/[A-Z0-9]+$/)
+  const partyUrl = page.url()
+  await page.getByPlaceholder('Your name (optional)').fill(name)
+  await page.getByRole('button', { name: 'Join', exact: true }).click()
+  await expect(page.getByText('1 watching')).toBeVisible()
+  return partyUrl
+}
+
+async function loginAndSelectMovie(page: Page): Promise<void> {
+  await page.getByRole('main').getByRole(
+    'button', { name: 'Login to Become Host', exact: true },
+  ).click()
+  await page.getByPlaceholder('Emby username').fill('Alice')
+  await page.getByPlaceholder('Emby password').fill('password')
+  await page.getByRole('button', { name: 'Become Host', exact: true }).click()
+  await page.getByText('Movies', { exact: true }).click()
+  await page.getByText('Fake Movie', { exact: true }).click()
+  await expect(page.locator('video#videoElement')).toHaveAttribute('title', 'Fake Movie')
+}
+
+async function expectOk(response: APIResponse, label: string): Promise<void> {
+  expect(response.status(), `${label} returned ${response.status()}`).toBe(200)
+}
+
+test('@playback-gate complete authenticated fake-Emby playback flow', async ({ browser, page }) => {
+  const watchedFailures: string[] = []
+  const masterRequests: string[] = []
+  let expectedBindLimit = false
+  const audit = (response: APIResponse) => {
+    if (![401, 403, 429].includes(response.status())) return
+    if (expectedBindLimit && response.status() === 429 && response.url().includes('/join')) return
+    watchedFailures.push(`${response.status()} ${response.url()}`)
+  }
+  page.on('response', audit)
+  page.on('request', (request) => {
+    if (request.url().includes('/hls/movie-1/master.m3u8')) {
+      masterRequests.push(request.url())
+    }
+  })
+
+  const ready = await page.request.get('/api/ready')
+  await expectOk(ready, 'readiness')
+  const partyUrl = await createAndJoin(page, 'Alice')
+
+  const guestContext = await browser.newContext()
+  const guest = await guestContext.newPage()
+  guest.on('response', audit)
+  await guest.goto(partyUrl)
+  await guest.getByPlaceholder('Your name (optional)').fill('Bob')
+  await guest.getByRole('button', { name: 'Join', exact: true }).click()
+  await expect(page.getByText('2 watching')).toBeVisible()
+
+  await loginAndSelectMovie(page)
+  const hostVideo = page.locator('video#videoElement')
+  const guestVideo = guest.locator('video#videoElement')
+  await expect(guestVideo).toHaveAttribute('title', 'Fake Movie')
+
+  await page.waitForFunction(() => {
+    const video = document.querySelector<HTMLVideoElement>('video#videoElement')
+    return video && video.readyState >= HTMLMediaElement.HAVE_FUTURE_DATA
+  })
+  await hostVideo.focus()
+  await hostVideo.press('Space')
+  await expect(guest.getByText('Alice started playback')).toBeVisible()
+  await page.waitForTimeout(600)
+  await hostVideo.press('Space')
+  await expect(guest.getByText('Alice paused playback')).toBeVisible()
+
+  await page.getByRole('button', { name: '+10s' }).click()
+  await expect(guest.getByText(/Alice seeked to/)).toBeVisible()
+  const forwardTime = await guestVideo.evaluate((video: HTMLVideoElement) => video.currentTime)
+  await page.getByRole('button', { name: '−10s' }).click()
+  await expect.poll(
+    () => guestVideo.evaluate((video: HTMLVideoElement) => video.currentTime),
+  ).toBeLessThan(forwardTime)
+
+  await expect.poll(() => masterRequests.length).toBeGreaterThan(0)
+  const masterUrl = masterRequests.at(-1)!
+  const master = await page.request.get(masterUrl)
+  await expectOk(master, 'authenticated HLS master playlist')
+  expect(master.headers()['content-type']).toContain('mpegurl')
+  const variantUrl = new URL(mediaUri(await master.text()), masterUrl).href
+  const variant = await page.request.get(variantUrl)
+  await expectOk(variant, 'authenticated HLS media playlist')
+  const segmentUrl = new URL(mediaUri(await variant.text()), variantUrl).href
+  const segment = await page.request.get(segmentUrl)
+  await expectOk(segment, 'authenticated HLS segment')
+  expect((await segment.body()).byteLength).toBeGreaterThan(0)
+  const range = await page.request.get(segmentUrl, { headers: { Range: 'bytes=0-17' } })
+  expect(range.status()).toBe(206)
+  expect(range.headers()['content-range']).toBe('bytes 0-17/168260')
+  expect((await range.body()).byteLength).toBe(18)
+
+  const audio = page.getByLabel('Audio')
+  await expect(audio.locator('option')).toHaveCount(2)
+  const sourceBeforeAudio = await hostVideo.getAttribute('src')
+  await audio.selectOption('2')
+  await expect(audio).toHaveValue('2')
+  await expect.poll(() => hostVideo.getAttribute('src')).not.toBe(sourceBeforeAudio)
+
+  const subtitles = page.getByLabel('Subtitles')
+  await expect(subtitles.locator('option')).toHaveCount(2)
+  await subtitles.selectOption('3')
+  await expect(subtitles).toHaveValue('3')
+  await expect.poll(
+    () => page.locator('video#videoElement track[kind="subtitles"]').count(),
+  ).toBe(1)
+
+  const sourceBeforeReconnect = await guestVideo.getAttribute('src')
+  await guestContext.setOffline(true)
+  await guest.evaluate(() => window.dispatchEvent(new Event('offline')))
+  await expect(guest.getByText('Reconnecting to party…')).toBeVisible()
+  await guestContext.setOffline(false)
+  await guest.evaluate(() => window.dispatchEvent(new Event('online')))
+  await expect(guest.getByText('Reconnecting to party…')).toBeHidden({ timeout: 15_000 })
+  await expect.poll(() => guestVideo.getAttribute('src')).not.toBe(sourceBeforeReconnect)
+  await expect(guest.getByText('2 watching')).toBeVisible()
+
+  let rejectedBind = false
+  await page.route('**/api/party/*/join', async (route) => {
+    if (rejectedBind) return route.continue()
+    rejectedBind = true
+    expectedBindLimit = true
+    return route.fulfill({
+      status: 429,
+      headers: { 'content-type': 'application/json', 'retry-after': '1' },
+      body: JSON.stringify({
+        detail: 'Too many party joins. Try again in 1 seconds.',
+        code: 'rate_limited',
+        retry_after: 1,
+      }),
+    })
+  })
+  await page.reload()
+  await expect(page.getByText(/Too many party joins/)).toBeVisible()
+  await expect(page.getByRole('button', { name: 'Retry' })).toBeEnabled({ timeout: 3_000 })
+  await page.getByRole('button', { name: 'Retry' }).click()
+  expectedBindLimit = false
+  await expect(page.getByText(/Too many party joins/)).toBeHidden()
+  await expect(page.getByText('2 watching')).toBeVisible()
+  await expect(page.locator('video#videoElement')).toHaveAttribute('title', 'Fake Movie')
+
+  const otherContext = await browser.newContext()
+  const created = await otherContext.request.post('/api/party/create', { data: {} })
+  expect(created.status()).toBe(200)
+  const otherParty = (await created.json()).party_id as string
+  const joined = await otherContext.request.post(`/api/party/${otherParty}/join`, {
+    data: { client_id: 'cross-party-client', display_name: 'Mallory' },
+  })
+  expect(joined.status()).toBe(200)
+  const otherLogin = await otherContext.request.post('/api/auth/login', {
+    data: { username: 'Mallory', password: 'password' },
+  })
+  expect(otherLogin.status()).toBe(200)
+  expect((await otherLogin.json()).success).toBe(true)
+  const denied = await otherContext.request.get(masterUrl)
+  expect([401, 403]).toContain(denied.status())
+
+  expect(watchedFailures, 'unexpected auth, rate-limit, or cross-party browser failures').toEqual([])
+  await otherContext.close()
+  await guestContext.close()
+})

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,8 @@
     "build-only": "vite build",
     "type-check": "vue-tsc --build",
     "test:unit": "vitest run",
-    "test:e2e": "playwright test"
+    "test:e2e": "playwright test",
+    "test:playback-gate": "playwright test --grep @playback-gate"
   },
   "dependencies": {
     "axios": "^1.13.6",

--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -37,6 +37,27 @@ describe('apiFetch', () => {
     )
   })
 
+  it('preserves structured rate-limit details and Retry-After', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(
+      JSON.stringify({
+        detail: 'Too many party join attempts. Try again in 42 seconds.',
+        code: 'rate_limited',
+        retry_after: 42,
+      }),
+      {
+        status: 429,
+        headers: { 'Content-Type': 'application/json', 'Retry-After': '42' },
+      },
+    )))
+
+    await expect(api.joinParty('ABC123', 'client-1', 'Alice')).rejects.toMatchObject({
+      status: 429,
+      message: 'Too many party join attempts. Try again in 42 seconds.',
+      code: 'rate_limited',
+      retryAfter: 42,
+    })
+  })
+
   it('preserves readable multipart upload errors', async () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(
       'Upload too large',

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -23,6 +23,8 @@ export class ApiError extends Error {
     public readonly status: number,
     message: string,
     public readonly body: JsonValue | undefined,
+    public readonly code?: string,
+    public readonly retryAfter?: number,
   ) {
     super(message)
     this.name = 'ApiError'
@@ -46,7 +48,13 @@ function responseError(resp: Response, body: JsonValue | undefined): ApiError {
     || (typeof body === 'string' && body)
     || resp.statusText
     || `Request failed (${resp.status})`
-  return new ApiError(resp.status, message, body)
+  const code = typeof record?.code === 'string' ? record.code : undefined
+  const bodyRetry = record?.retry_after
+  const headerRetry = Number.parseInt(resp.headers.get('Retry-After') || '', 10)
+  const retryAfter = typeof bodyRetry === 'number' && Number.isFinite(bodyRetry)
+    ? Math.max(0, Math.ceil(bodyRetry))
+    : Number.isFinite(headerRetry) ? Math.max(0, headerRetry) : undefined
+  return new ApiError(resp.status, message, body, code, retryAfter)
 }
 
 export interface SuccessResponse { success?: boolean; message?: string }

--- a/frontend/src/components/AvatarSetupModal.test.ts
+++ b/frontend/src/components/AvatarSetupModal.test.ts
@@ -1,0 +1,31 @@
+import { flushPromises, mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { describe, expect, it, vi } from 'vitest'
+
+import { ApiError } from '@/api/client'
+import { useAvatarStore } from '@/stores/avatar'
+import AvatarSetupModal from './AvatarSetupModal.vue'
+
+describe('avatar recovery failures', () => {
+  it('shows the backend rate-limit detail inline', async () => {
+    const pinia = createPinia()
+    setActivePinia(pinia)
+    vi.spyOn(useAvatarStore(), 'recover').mockRejectedValue(new ApiError(
+      429,
+      'Too many avatar recovery attempts. Try again in 90 seconds.',
+      { code: 'rate_limited', retry_after: 90 },
+      'rate_limited',
+      90,
+    ))
+    const wrapper = mount(AvatarSetupModal, { global: { plugins: [pinia] } })
+
+    await wrapper.get('.tabs button:nth-child(3)').trigger('click')
+    await wrapper.get('input[placeholder="word-word-word"]').setValue('able-acid-aged')
+    await wrapper.get('.tab-body button').trigger('click')
+    await flushPromises()
+
+    expect(wrapper.get('.error').text()).toBe(
+      'Too many avatar recovery attempts. Try again in 90 seconds.',
+    )
+  })
+})

--- a/frontend/src/components/AvatarSetupModal.vue
+++ b/frontend/src/components/AvatarSetupModal.vue
@@ -20,6 +20,10 @@ const email = ref('')
 const recoverCode = ref('')
 const copyLabel = ref('Copy')
 
+function readableError(value: unknown, fallback: string): string {
+  return value instanceof Error ? value.message : fallback
+}
+
 function pickFile(ev: Event) {
   const input = ev.target as HTMLInputElement
   const f = input.files?.[0] || null
@@ -39,6 +43,8 @@ async function submitUpload() {
     if (!res.success) {
       error.value = res.message || 'Upload failed'
     }
+  } catch (reason: unknown) {
+    error.value = readableError(reason, 'Upload failed')
   } finally {
     busy.value = false
   }
@@ -56,6 +62,8 @@ async function submitGravatar() {
     if (!res.success) {
       error.value = res.message || 'Could not register Gravatar'
     }
+  } catch (reason: unknown) {
+    error.value = readableError(reason, 'Could not register Gravatar')
   } finally {
     busy.value = false
   }
@@ -75,6 +83,8 @@ async function submitRecover() {
     } else {
       error.value = res.message || 'Code not recognised'
     }
+  } catch (reason: unknown) {
+    error.value = readableError(reason, 'Code not recognised')
   } finally {
     busy.value = false
   }

--- a/frontend/src/composables/usePartyChat.test.ts
+++ b/frontend/src/composables/usePartyChat.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from 'vitest'
+import { usePartyChat } from './usePartyChat'
+
+describe('usePartyChat', () => {
+  it('restores a rate-limited draft without resending it', () => {
+    vi.useFakeTimers()
+    const handlers = new Map<string, (data: never) => void>()
+    const socket = {
+      emit: vi.fn(),
+      on: vi.fn((event: string, handler: (data: never) => void) => handlers.set(event, handler)),
+      off: vi.fn(),
+    }
+    const party = { partyId: 'ABC123' }
+    const chat = usePartyChat(socket as never, party as never)
+    chat.attach()
+    chat.input.value = 'please keep this'
+
+    chat.send()
+    const payload = socket.emit.mock.calls[0]?.[1]
+    expect(payload.request_id).toEqual(expect.any(String))
+    expect(chat.input.value).toBe('')
+
+    handlers.get('rate_limited')?.({
+      action: 'chat',
+      message: 'Message not sent. Try again in 2 seconds.',
+      retry_after: 2,
+      request_id: payload.request_id,
+    } as never)
+
+    expect(chat.input.value).toBe('please keep this')
+    expect(chat.rateLimitError.value).toContain('not sent')
+    expect(chat.rateLimitRetryAfter.value).toBe(2)
+    vi.advanceTimersByTime(2000)
+    expect(chat.rateLimitRetryAfter.value).toBe(0)
+    expect(socket.emit).toHaveBeenCalledTimes(1)
+    vi.useRealTimers()
+  })
+})

--- a/frontend/src/composables/usePartyChat.ts
+++ b/frontend/src/composables/usePartyChat.ts
@@ -19,6 +19,11 @@ export function usePartyChat(socket: SocketStore, party: PartyStore) {
   const input = ref('')
   const showParticipants = ref(false)
   const showMobileChat = ref(false)
+  const rateLimitError = ref<string | null>(null)
+  const rateLimitRetryAfter = ref(0)
+  const pendingDrafts = new Map<string, string>()
+  const pendingTimers = new Map<string, ReturnType<typeof setTimeout>>()
+  let rateLimitTimer: ReturnType<typeof setInterval> | null = null
 
   const receiveMessage = (data: ServerToClientPayloads['chat_message']) => {
     messages.value.push(data)
@@ -28,20 +33,61 @@ export function usePartyChat(socket: SocketStore, party: PartyStore) {
     })
   }
 
+  const receiveRateLimit = (data: ServerToClientPayloads['rate_limited']) => {
+    if (data.action !== 'chat') return
+    const draft = data.request_id ? pendingDrafts.get(data.request_id) : undefined
+    if (draft) {
+      input.value = input.value ? `${draft} ${input.value}` : draft
+      pendingDrafts.delete(data.request_id!)
+      const pendingTimer = pendingTimers.get(data.request_id!)
+      if (pendingTimer) clearTimeout(pendingTimer)
+      pendingTimers.delete(data.request_id!)
+    }
+    rateLimitError.value = data.message
+    rateLimitRetryAfter.value = Math.max(1, Math.ceil(data.retry_after))
+    if (rateLimitTimer) clearInterval(rateLimitTimer)
+    rateLimitTimer = setInterval(() => {
+      rateLimitRetryAfter.value = Math.max(0, rateLimitRetryAfter.value - 1)
+      if (rateLimitRetryAfter.value === 0 && rateLimitTimer) {
+        clearInterval(rateLimitTimer)
+        rateLimitTimer = null
+      }
+    }, 1000)
+  }
+
   function attach() {
     socket.off('chat_message', receiveMessage)
     socket.on('chat_message', receiveMessage)
+    socket.off('rate_limited', receiveRateLimit)
+    socket.on('rate_limited', receiveRateLimit)
   }
 
   function dispose() {
     socket.off('chat_message', receiveMessage)
+    socket.off('rate_limited', receiveRateLimit)
+    if (rateLimitTimer) clearInterval(rateLimitTimer)
+    rateLimitTimer = null
+    for (const timer of pendingTimers.values()) clearTimeout(timer)
+    pendingTimers.clear()
+    pendingDrafts.clear()
   }
 
   function send() {
     const message = input.value.trim()
-    if (!message || !party.partyId) return
-    socket.emit('chat_message', { party_id: party.partyId, message })
+    if (!message || !party.partyId || rateLimitRetryAfter.value > 0) return
+    const requestId = `${Date.now()}-${Math.random().toString(36).slice(2)}`
+    pendingDrafts.set(requestId, message)
+    pendingTimers.set(requestId, setTimeout(() => {
+      pendingDrafts.delete(requestId)
+      pendingTimers.delete(requestId)
+    }, 60_000))
+    socket.emit('chat_message', {
+      party_id: party.partyId,
+      message,
+      request_id: requestId,
+    })
     input.value = ''
+    rateLimitError.value = null
   }
 
   function insertEmoji(emoji: string) {
@@ -62,6 +108,8 @@ export function usePartyChat(socket: SocketStore, party: PartyStore) {
     input,
     showParticipants,
     showMobileChat,
+    rateLimitError,
+    rateLimitRetryAfter,
     attach,
     dispose,
     send,

--- a/frontend/src/stores/party.test.ts
+++ b/frontend/src/stores/party.test.ts
@@ -51,4 +51,34 @@ describe('party socket listeners', () => {
     expect(party.sessionRetryAfter).toBe(42)
     vi.useRealTimers()
   })
+
+  it('identifies a different-party binding from another tab', async () => {
+    const channels: Array<{
+      onmessage: ((event: { data: { partyId: string } }) => void) | null
+      postMessage: ReturnType<typeof vi.fn>
+    }> = []
+    vi.stubGlobal('BroadcastChannel', class {
+      onmessage: ((event: { data: { partyId: string } }) => void) | null = null
+      postMessage = vi.fn()
+
+      constructor() {
+        channels.push(this)
+      }
+    })
+    const socket = useSocketStore()
+    vi.spyOn(socket, 'emit').mockImplementation(() => undefined)
+    vi.spyOn(api, 'joinParty').mockResolvedValue({ success: true })
+    vi.spyOn(api, 'authStatus').mockRejectedValue(new Error('not needed'))
+
+    const party = usePartyStore()
+    await party.join('ABC123', 'Alice')
+
+    expect(channels).toHaveLength(1)
+    expect(channels[0]?.postMessage).toHaveBeenCalledWith({ partyId: 'ABC123' })
+    channels[0]?.onmessage?.({ data: { partyId: 'ABC123' } })
+    expect(party.supersededBy).toBeNull()
+    channels[0]?.onmessage?.({ data: { partyId: 'XYZ789' } })
+    expect(party.supersededBy).toBe('XYZ789')
+    vi.unstubAllGlobals()
+  })
 })

--- a/frontend/src/stores/party.test.ts
+++ b/frontend/src/stores/party.test.ts
@@ -1,6 +1,7 @@
 import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { ApiError, api } from '@/api/client'
 import { usePartyStore } from './party'
 import { useSocketStore } from './socket'
 
@@ -26,5 +27,28 @@ describe('party socket listeners', () => {
     party.setupListeners()
 
     expect(handlers.get('members_update')?.size).toBe(1)
+  })
+
+  it('surfaces a limited session bind without retrying the mutating request', async () => {
+    vi.useFakeTimers()
+    const socket = useSocketStore()
+    vi.spyOn(socket, 'emit').mockImplementation(() => undefined)
+    const join = vi.spyOn(api, 'joinParty').mockRejectedValue(new ApiError(
+      429,
+      'Too many party join attempts. Try again in 42 seconds.',
+      { code: 'rate_limited', retry_after: 42 },
+      'rate_limited',
+      42,
+    ))
+
+    const party = usePartyStore()
+    await party.join('ABC123', 'Alice')
+
+    expect(join).toHaveBeenCalledTimes(1)
+    expect(party.sessionError).toBe(
+      'Too many party join attempts. Try again in 42 seconds.',
+    )
+    expect(party.sessionRetryAfter).toBe(42)
+    vi.useRealTimers()
   })
 })

--- a/frontend/src/stores/party.ts
+++ b/frontend/src/stores/party.ts
@@ -3,7 +3,7 @@ import { ref, computed } from 'vue'
 import { useSocketStore } from './socket'
 import { useAvatarStore } from './avatar'
 import { useAuthStore } from './auth'
-import { api } from '@/api/client'
+import { ApiError, api } from '@/api/client'
 import type { ServerToClientPayloads } from '@/types/socket.generated'
 
 export interface MemberInfo {
@@ -64,6 +64,23 @@ export const usePartyStore = defineStore('party', () => {
   // retry and an unreproducible "video won't load for one person".
   const sessionError = ref<string | null>(null)
   const sessionRetrying = ref(false)
+  const sessionRetryAfter = ref(0)
+  let sessionRetryTimer: ReturnType<typeof setInterval> | null = null
+
+  function clearSessionRetryCountdown() {
+    if (sessionRetryTimer) clearInterval(sessionRetryTimer)
+    sessionRetryTimer = null
+    sessionRetryAfter.value = 0
+  }
+
+  function startSessionRetryCountdown(seconds: number) {
+    clearSessionRetryCountdown()
+    sessionRetryAfter.value = Math.max(1, Math.ceil(seconds))
+    sessionRetryTimer = setInterval(() => {
+      sessionRetryAfter.value = Math.max(0, sessionRetryAfter.value - 1)
+      if (sessionRetryAfter.value === 0) clearSessionRetryCountdown()
+    }, 1000)
+  }
 
   // Set to the other party's code when a different tab in this browser
   // takes over the session cookie. See PARTY_BINDING_CHANNEL above.
@@ -194,8 +211,14 @@ export const usePartyStore = defineStore('party', () => {
         // for a party that was already unlocked when they joined).
         try { await auth.refresh() } catch { /* ignore */ }
         sessionError.value = null
+        clearSessionRetryCountdown()
         return true
       } catch (e: unknown) {
+        if (e instanceof ApiError && e.code === 'rate_limited') {
+          sessionError.value = e.message
+          startSessionRetryCountdown(e.retryAfter || 1)
+          break
+        }
         if (attempt === 0) {
           await new Promise((r) => setTimeout(r, 600))
           continue
@@ -209,7 +232,10 @@ export const usePartyStore = defineStore('party', () => {
 
   /** Re-attempt the session cookie after a visible failure. */
   async function retrySession() {
-    if (!lastJoinArgs || !partyId.value || sessionRetrying.value) return false
+    if (
+      !lastJoinArgs || !partyId.value || sessionRetrying.value
+      || sessionRetryAfter.value > 0
+    ) return false
     sessionRetrying.value = true
     try {
       const { clientId, name, avatarUuid } = lastJoinArgs
@@ -254,6 +280,7 @@ export const usePartyStore = defineStore('party', () => {
     waitingUsers.value = []
     pendingVote.value = null
     sessionError.value = null
+    clearSessionRetryCountdown()
     supersededBy.value = null
   }
 
@@ -519,7 +546,7 @@ export const usePartyStore = defineStore('party', () => {
     myStreamUrl, streamOffset, readyCheckActive, readyUsers, waitingUsers,
     pendingVote,
     bingeWatch, pendingAutoAdvance,
-    sessionError, sessionRetrying, supersededBy,
+    sessionError, sessionRetrying, sessionRetryAfter, supersededBy,
     join, leave, setupListeners, submitVote, retrySession,
     setBingeWatchActive, cancelAutoAdvance,
   }

--- a/frontend/src/stores/socket.test.ts
+++ b/frontend/src/stores/socket.test.ts
@@ -1,0 +1,53 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const socketHarness = vi.hoisted(() => {
+  const handlers = new Map<string, (value?: unknown) => void>()
+  return {
+    handlers,
+    socket: {
+      on: vi.fn((event: string, handler: (value?: unknown) => void) => {
+        handlers.set(event, handler)
+      }),
+      emit: vi.fn(),
+      off: vi.fn(),
+      disconnect: vi.fn(),
+      connect: vi.fn(),
+      io: { reconnection: vi.fn() },
+    },
+  }
+})
+
+vi.mock('socket.io-client', () => ({ io: () => socketHarness.socket }))
+
+import { useSocketStore } from './socket'
+
+describe('socket connection rate limits', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.clearAllMocks()
+    socketHarness.handlers.clear()
+    setActivePinia(createPinia())
+  })
+
+  it('shows the refusal, pauses reconnects, then reconnects after Retry-After', () => {
+    const store = useSocketStore()
+    store.connect()
+    const error = Object.assign(new Error(
+      'Too many connection attempts. Try again in 2 seconds.',
+    ), { data: { code: 'rate_limited', retry_after: 2 } })
+
+    socketHarness.handlers.get('connect_error')!(error)
+
+    expect(store.connectionError).toBe(error.message)
+    expect(store.connectionRetryAfter).toBe(2)
+    expect(socketHarness.socket.io.reconnection).toHaveBeenCalledWith(false)
+
+    vi.advanceTimersByTime(2000)
+
+    expect(socketHarness.socket.io.reconnection).toHaveBeenLastCalledWith(true)
+    expect(socketHarness.socket.connect).toHaveBeenCalledTimes(1)
+    expect(store.connectionRetryAfter).toBe(0)
+    vi.useRealTimers()
+  })
+})

--- a/frontend/src/stores/socket.ts
+++ b/frontend/src/stores/socket.ts
@@ -14,7 +14,19 @@ export const useSocketStore = defineStore('socket', () => {
   // only fires on the reconnect edge.
   const hasEverConnected = ref(false)
   const reconnecting = ref(false)
+  const connectionError = ref<string | null>(null)
+  const connectionRetryAfter = ref(0)
   let networkListenersInstalled = false
+  let connectionRetryTimer: ReturnType<typeof setInterval> | null = null
+  let reconnectTimer: ReturnType<typeof setTimeout> | null = null
+
+  function clearConnectionRetry() {
+    if (connectionRetryTimer) clearInterval(connectionRetryTimer)
+    if (reconnectTimer) clearTimeout(reconnectTimer)
+    connectionRetryTimer = null
+    reconnectTimer = null
+    connectionRetryAfter.value = 0
+  }
 
   function connect() {
     // Skip if a socket already exists for this Pinia singleton, even
@@ -48,6 +60,8 @@ export const useSocketStore = defineStore('socket', () => {
     })
 
     s.on('connect', () => {
+      clearConnectionRetry()
+      connectionError.value = null
       connected.value = true
       hasEverConnected.value = true
       reconnecting.value = false
@@ -65,18 +79,40 @@ export const useSocketStore = defineStore('socket', () => {
 
     // Surface handshake failures so the UI does not silently hang when
     // the backend rejects the connection or the WS upgrade fails.
-    s.on('connect_error', (err: Error) => {
+    s.on('connect_error', (err: Error & {
+      data?: { code?: string; retry_after?: number }
+    }) => {
       console.warn('Socket connect_error:', err.message)
+      connectionError.value = err.message || 'Could not connect to the party.'
+      if (err.data?.code !== 'rate_limited') return
+
+      const retryAfter = Math.max(1, Math.ceil(err.data.retry_after || 1))
+      clearConnectionRetry()
+      connectionRetryAfter.value = retryAfter
+      s.io.reconnection(false)
+      connectionRetryTimer = setInterval(() => {
+        connectionRetryAfter.value = Math.max(0, connectionRetryAfter.value - 1)
+      }, 1000)
+      reconnectTimer = setTimeout(() => {
+        if (connectionRetryTimer) clearInterval(connectionRetryTimer)
+        connectionRetryTimer = null
+        reconnectTimer = null
+        connectionRetryAfter.value = 0
+        s.io.reconnection(true)
+        s.connect()
+      }, retryAfter * 1000)
     })
 
     socket.value = s
   }
 
   function disconnect() {
+    clearConnectionRetry()
     socket.value?.disconnect()
     socket.value = null
     connected.value = false
     reconnecting.value = false
+    connectionError.value = null
     sid.value = null
   }
 
@@ -107,6 +143,8 @@ export const useSocketStore = defineStore('socket', () => {
     sid,
     hasEverConnected,
     reconnecting,
+    connectionError,
+    connectionRetryAfter,
     connect,
     disconnect,
     emit,

--- a/frontend/src/types/socket.generated.ts
+++ b/frontend/src/types/socket.generated.ts
@@ -12,6 +12,7 @@ export interface ClientToServerPayloads {
   "chat_message": {
     "party_id": string
     "message": string
+    "request_id"?: string | null
   }
   "heartbeat": {
     "party_id": string
@@ -210,6 +211,12 @@ export interface ServerToClientPayloads {
     "playing"?: boolean | null
     "auto_binge"?: boolean | null
     "wait_for_ready"?: boolean | null
+  }
+  "rate_limited": {
+    "message": string
+    "action": string
+    "retry_after": number
+    "request_id"?: string | null
   }
   "ready_check_update": {
     "ready"?: string[]

--- a/frontend/src/views/AdminView.test.ts
+++ b/frontend/src/views/AdminView.test.ts
@@ -1,0 +1,32 @@
+import { flushPromises, mount } from '@vue/test-utils'
+import { createPinia } from 'pinia'
+import { describe, expect, it, vi } from 'vitest'
+
+import { ApiError, api } from '@/api/client'
+import AdminView from './AdminView.vue'
+
+describe('admin login failures', () => {
+  it('shows the backend rate-limit detail inline', async () => {
+    vi.spyOn(api, 'adminGetConfig').mockRejectedValue(new Error('Not authenticated'))
+    vi.spyOn(api, 'adminLogin').mockRejectedValue(new ApiError(
+      429,
+      'Too many login attempts. Try again in 30 seconds.',
+      { code: 'rate_limited', retry_after: 30 },
+      'rate_limited',
+      30,
+    ))
+    const wrapper = mount(AdminView, {
+      global: { plugins: [createPinia()], stubs: { RouterLink: true } },
+    })
+
+    const inputs = wrapper.findAll('input')
+    await inputs[0]!.setValue('Alice')
+    await inputs[1]!.setValue('password')
+    await wrapper.get('form').trigger('submit')
+    await flushPromises()
+
+    expect(wrapper.get('.error-msg').text()).toBe(
+      'Too many login attempts. Try again in 30 seconds.',
+    )
+  })
+})

--- a/frontend/src/views/AdminView.vue
+++ b/frontend/src/views/AdminView.vue
@@ -22,11 +22,15 @@ const loginError = ref('')
 
 async function adminLogin() {
   loginError.value = ''
-  const result = await api.adminLogin(loginUser.value, loginPass.value)
-  if (result.success) {
-    authenticated.value = true
-  } else {
-    loginError.value = result.message || 'Login failed'
+  try {
+    const result = await api.adminLogin(loginUser.value, loginPass.value)
+    if (result.success) {
+      authenticated.value = true
+    } else {
+      loginError.value = result.message || 'Login failed'
+    }
+  } catch (error: unknown) {
+    loginError.value = error instanceof Error ? error.message : 'Login failed'
   }
 }
 

--- a/frontend/src/views/IndexView.test.ts
+++ b/frontend/src/views/IndexView.test.ts
@@ -1,0 +1,44 @@
+import { flushPromises, mount } from '@vue/test-utils'
+import { createPinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ApiError, api } from '@/api/client'
+import IndexView from './IndexView.vue'
+
+const push = vi.fn()
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push, replace: vi.fn() }),
+}))
+
+describe('party creation failures', () => {
+  beforeEach(() => {
+    push.mockReset()
+    vi.spyOn(api, 'listParties').mockResolvedValue({ require_login: false, parties: [] })
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('{}', { status: 200 })))
+  })
+
+  it('shows the backend rate-limit detail instead of leaving an unhandled request', async () => {
+    vi.spyOn(api, 'createParty').mockRejectedValue(new ApiError(
+      429,
+      'Too many party creation attempts. Try again in 60 seconds.',
+      { code: 'rate_limited', retry_after: 60 },
+      'rate_limited',
+      60,
+    ))
+    const wrapper = mount(IndexView, {
+      global: {
+        plugins: [createPinia()],
+        stubs: { EmbyLoginModal: true, RouterLink: true },
+      },
+    })
+
+    await wrapper.get('.action-card button').trigger('click')
+    await flushPromises()
+
+    expect(wrapper.get('.status-msg').text()).toBe(
+      'Too many party creation attempts. Try again in 60 seconds.',
+    )
+    expect(push).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/views/IndexView.test.ts
+++ b/frontend/src/views/IndexView.test.ts
@@ -13,6 +13,7 @@ vi.mock('vue-router', () => ({
 
 describe('party creation failures', () => {
   beforeEach(() => {
+    vi.restoreAllMocks()
     push.mockReset()
     vi.spyOn(api, 'listParties').mockResolvedValue({ require_login: false, parties: [] })
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('{}', { status: 200 })))
@@ -40,5 +41,27 @@ describe('party creation failures', () => {
       'Too many party creation attempts. Try again in 60 seconds.',
     )
     expect(push).not.toHaveBeenCalled()
+  })
+
+  it('shows one contextual status when party-list polling is limited', async () => {
+    vi.mocked(api.listParties).mockRejectedValue(new ApiError(
+      429,
+      'Too many requests. Try again in 15 seconds.',
+      { code: 'rate_limited', retry_after: 15 },
+      'rate_limited',
+      15,
+    ))
+
+    const wrapper = mount(IndexView, {
+      global: {
+        plugins: [createPinia()],
+        stubs: { EmbyLoginModal: true, RouterLink: true },
+      },
+    })
+    await flushPromises()
+
+    expect(wrapper.get('[data-testid="party-list-status"]').text()).toBe(
+      'Too many requests. Try again in 15 seconds.',
+    )
   })
 })

--- a/frontend/src/views/IndexView.vue
+++ b/frontend/src/views/IndexView.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { ref, onMounted, onUnmounted, defineAsyncComponent } from 'vue'
 import { useRouter } from 'vue-router'
-import { api } from '@/api/client'
+import { ApiError, api } from '@/api/client'
 import { withPrefix } from '@/utils/appPrefix'
 import { useAuthStore } from '@/stores/auth'
 import { getHiddenParties } from '@/utils/hiddenParties'
@@ -27,6 +27,7 @@ interface ActiveParty {
   locked: boolean
 }
 const parties = ref<ActiveParty[]>([])
+const partyListStatus = ref('')
 let pollTimer: ReturnType<typeof setInterval> | null = null
 
 async function loadParties() {
@@ -38,8 +39,11 @@ async function loadParties() {
     const data = await api.listParties()
     const hidden = getHiddenParties()
     parties.value = (data.parties || []).filter((p: ActiveParty) => !hidden.includes(p.code))
-  } catch {
-    /* ignore transient errors; the next poll retries */
+    partyListStatus.value = ''
+  } catch (error: unknown) {
+    if (error instanceof ApiError && error.code === 'rate_limited') {
+      partyListStatus.value = error.message
+    }
   }
 }
 
@@ -172,6 +176,15 @@ function joinParty() {
         </div>
       </div>
     </main>
+
+    <div
+      v-if="partyListStatus"
+      class="status-msg"
+      data-testid="party-list-status"
+      role="status"
+    >
+      {{ partyListStatus }}
+    </div>
 
     <section v-if="!auth.requireLogin && parties.length" class="active-parties">
       <h2 class="ap-heading">Active parties</h2>

--- a/frontend/src/views/IndexView.vue
+++ b/frontend/src/views/IndexView.vue
@@ -93,11 +93,15 @@ async function createParty() {
     return
   }
   status.value = 'Creating party...'
-  const data = await api.createParty({ client_id: getClientId() })
-  if (data.party_id) {
-    router.push(`/party/${data.party_id}`)
-  } else {
-    status.value = data.message || 'Error creating party'
+  try {
+    const data = await api.createParty({ client_id: getClientId() })
+    if (data.party_id) {
+      router.push(`/party/${data.party_id}`)
+    } else {
+      status.value = data.message || 'Error creating party'
+    }
+  } catch (error: unknown) {
+    status.value = error instanceof Error ? error.message : 'Error creating party'
   }
 }
 
@@ -105,17 +109,21 @@ async function submitCreateLogin(payload: { username: string; password: string }
   createBusy.value = true
   createError.value = null
   try {
-    const data = await api.createParty({
-      client_id: getClientId(),
-      display_name: payload.username,
-      username: payload.username,
-      password: payload.password,
-    })
-    if (data.party_id) {
-      showCreateModal.value = false
-      router.push(`/party/${data.party_id}`)
-    } else {
-      createError.value = data.message || 'Could not create the party'
+    try {
+      const data = await api.createParty({
+        client_id: getClientId(),
+        display_name: payload.username,
+        username: payload.username,
+        password: payload.password,
+      })
+      if (data.party_id) {
+        showCreateModal.value = false
+        router.push(`/party/${data.party_id}`)
+      } else {
+        createError.value = data.message || 'Could not create the party'
+      }
+    } catch (error: unknown) {
+      createError.value = error instanceof Error ? error.message : 'Could not create the party'
     }
   } finally {
     createBusy.value = false

--- a/frontend/src/views/PartyView.vue
+++ b/frontend/src/views/PartyView.vue
@@ -1075,15 +1075,18 @@ async function submitBecomeHost(payload: { username: string; password: string })
       aria-live="assertive"
     >
       <span>
-        Could not authenticate with the server, so video will not load.
-        Chat and the participant list still work.
+        {{ party.sessionError }} Video will not load until this succeeds.
       </span>
       <button
         class="session-retry"
-        :disabled="party.sessionRetrying"
+        :disabled="party.sessionRetrying || party.sessionRetryAfter > 0"
         @click="party.retrySession()"
       >
-        {{ party.sessionRetrying ? 'Retrying…' : 'Retry' }}
+        {{ party.sessionRetrying
+          ? 'Retrying…'
+          : party.sessionRetryAfter > 0
+            ? `Retry in ${party.sessionRetryAfter}s`
+            : 'Retry' }}
       </button>
     </div>
     <header class="party-header">

--- a/frontend/src/views/PartyView.vue
+++ b/frontend/src/views/PartyView.vue
@@ -73,6 +73,8 @@ const {
   input: chatInput,
   showParticipants,
   showMobileChat,
+  rateLimitError: chatRateLimitError,
+  rateLimitRetryAfter: chatRateLimitRetryAfter,
   attach: attachChat,
   dispose: disposeChat,
   send: sendChat,
@@ -1313,10 +1315,22 @@ async function submitBecomeHost(payload: { username: string; password: string })
               placeholder="Type a message..."
               class="chat-composer-input"
             />
-            <button @click="sendChat" class="chat-composer-send" title="Send" aria-label="Send message">
+            <button
+              @click="sendChat"
+              class="chat-composer-send"
+              title="Send"
+              aria-label="Send message"
+              :disabled="chatRateLimitRetryAfter > 0"
+            >
               <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="22" y1="2" x2="11" y2="13"/><polygon points="22 2 15 22 11 13 2 9 22 2"/></svg>
             </button>
           </div>
+          <p v-if="chatRateLimitError" class="form-error" role="alert">
+            {{ chatRateLimitError }}
+            <span v-if="chatRateLimitRetryAfter > 0">
+              Retry in {{ chatRateLimitRetryAfter }}s.
+            </span>
+          </p>
         </div>
       </aside>
       <button

--- a/frontend/src/views/PartyView.vue
+++ b/frontend/src/views/PartyView.vue
@@ -1000,6 +1000,10 @@ async function submitBecomeHost(payload: { username: string; password: string })
     } else {
       becomeHostError.value = data.message || 'Login failed'
     }
+  } catch (error: unknown) {
+    becomeHostError.value = error instanceof Error && error.message
+      ? error.message
+      : 'Login failed'
   } finally {
     becomeHostBusy.value = false
   }

--- a/frontend/src/views/PartyView.vue
+++ b/frontend/src/views/PartyView.vue
@@ -1005,6 +1005,17 @@ async function submitBecomeHost(payload: { username: string; password: string })
 </script>
 
 <template>
+  <div
+    v-if="socket.connectionError"
+    class="session-banner"
+    role="alert"
+    aria-live="assertive"
+  >
+    <span>{{ socket.connectionError }}</span>
+    <span v-if="socket.connectionRetryAfter > 0">
+      Reconnecting in {{ socket.connectionRetryAfter }}s.
+    </span>
+  </div>
   <!-- Auto-join spinner: shown when we have a saved username and are
        waiting on the socket to confirm the join. Suppresses the name
        modal flash-of-stale-UI on every mount / refresh. -->

--- a/tests/support/fake_emby.py
+++ b/tests/support/fake_emby.py
@@ -49,6 +49,27 @@ MOVIE: dict[str, Any] = {
                     "Codec": "aac",
                     "Language": "eng",
                     "DisplayTitle": "English AAC",
+                    "Channels": 2,
+                    "IsDefault": True,
+                },
+                {
+                    "Index": 2,
+                    "Type": "Audio",
+                    "Codec": "aac",
+                    "Language": "spa",
+                    "DisplayTitle": "Spanish AAC",
+                    "Channels": 2,
+                    "IsDefault": False,
+                },
+                {
+                    "Index": 3,
+                    "Type": "Subtitle",
+                    "Codec": "subrip",
+                    "Language": "eng",
+                    "DisplayTitle": "English SRT",
+                    "IsDefault": False,
+                    "IsExternal": True,
+                    "IsTextSubtitleStream": True,
                 },
             ],
         }
@@ -259,6 +280,15 @@ def create_fake_emby_app(state: FakeEmbyState | None = None) -> FastAPI:
             "PlaySessionId": "play-session-1",
             "MediaSources": [{**MOVIE["MediaSources"][0], "ItemId": item_id}],
         }
+
+    @app.get("/emby/Videos/{item_id}/{source_id}/Subtitles/{index}/Stream.vtt")
+    async def subtitle_stream(request: Request, item_id: str, source_id: str, index: int):
+        del item_id, source_id, index
+        state.record(request)
+        return Response(
+            content="WEBVTT\n\n00:00:00.000 --> 00:00:05.000\nFake subtitle\n",
+            media_type="text/vtt",
+        )
 
     @app.api_route("/emby/Sessions/Playing{suffix:path}", methods=["POST"])
     async def playback_report(request: Request, suffix: str):

--- a/tests/test_admin_session_security.py
+++ b/tests/test_admin_session_security.py
@@ -206,7 +206,12 @@ def test_admin_login_limit_expires_and_returns_retry_after(tmp_path: Path) -> No
             assert (await _login(client)).status_code == 200
             limited = await _login(client)
             assert limited.status_code == 429
-            assert int(limited.headers["retry-after"]) > 0
+            retry_after = int(limited.headers["retry-after"])
+            assert limited.json() == {
+                "detail": f"Too many login attempts. Try again in {retry_after} seconds.",
+                "code": "rate_limited",
+                "retry_after": retry_after,
+            }
             await asyncio.sleep(1.05)
             assert (await _login(client)).status_code == 200
 

--- a/tests/test_chat_rate_limit.py
+++ b/tests/test_chat_rate_limit.py
@@ -16,10 +16,15 @@ async def _exercise_chat_limit(live_watchparty) -> None:
 
         realtime = socketio.AsyncClient()
         messages: list[str] = []
+        limited: list[dict] = []
 
         @realtime.on("chat_message")
         async def receive_chat(data):
             messages.append(data["message"])
+
+        @realtime.on("rate_limited")
+        async def receive_rate_limit(data):
+            limited.append(data)
 
         await realtime.connect(live_watchparty.url, headers={"Cookie": cookie})
         await realtime.emit(
@@ -38,10 +43,16 @@ async def _exercise_chat_limit(live_watchparty) -> None:
                 {
                     "party_id": party_id,
                     "message": f"burst-{index}",
+                    "request_id": f"chat-{index}",
                 },
             )
         await asyncio.sleep(0.15)
         assert messages == [f"burst-{index}" for index in range(5)]
+        assert len(limited) == 1
+        assert limited[0]["action"] == "chat"
+        assert limited[0]["request_id"] == "chat-5"
+        assert limited[0]["retry_after"] >= 1
+        assert "not sent" in limited[0]["message"].lower()
 
         await asyncio.sleep(3.05)
         await realtime.emit(

--- a/tests/test_fake_emby.py
+++ b/tests/test_fake_emby.py
@@ -10,6 +10,8 @@ def test_fake_emby_auth_library_hls_and_recording(fake_emby_server) -> None:
         libraries = client.get("/emby/Users/user-1/Views")
         playlist = client.get("/emby/Videos/movie-1/main.m3u8")
         intros = client.get("/emby/Items/Intros", params={"api_key": "test-key"})
+        item = client.get("/emby/Items/movie-1")
+        subtitle = client.get("/emby/Videos/movie-1/source-1/Subtitles/3/Stream.vtt")
         recorded = client.get("/__test__/requests")
 
     assert auth.status_code == 200
@@ -19,6 +21,10 @@ def test_fake_emby_auth_library_hls_and_recording(fake_emby_server) -> None:
     assert "segment0.ts" in playlist.text
     assert intros.status_code == 200
     assert isinstance(intros.json(), list)
+    streams = item.json()["MediaSources"][0]["MediaStreams"]
+    assert [stream["Index"] for stream in streams if stream["Type"] == "Audio"] == [1, 2]
+    assert [stream["Index"] for stream in streams if stream["Type"] == "Subtitle"] == [3]
+    assert subtitle.text.startswith("WEBVTT\n")
     request_rows = recorded.json()["requests"]
     assert any(row["path"].endswith("AuthenticateByName") for row in request_rows)
     assert "password" not in recorded.text

--- a/tests/test_migration_preflight.py
+++ b/tests/test_migration_preflight.py
@@ -1,0 +1,99 @@
+import hashlib
+from pathlib import Path
+
+from backend.migration_preflight import run_preflight
+
+
+def _fingerprint(root: Path) -> dict[str, tuple[str, int]]:
+    return {
+        str(path.relative_to(root)): (
+            hashlib.sha256(path.read_bytes()).hexdigest(),
+            path.stat().st_mtime_ns,
+        )
+        for path in root.rglob("*")
+        if path.is_file()
+    }
+
+
+def test_preflight_reports_precedence_rates_and_never_writes_or_prints_secrets(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / ".env").write_text(
+        "BEHIND_PROXY=true\n"
+        "TRUSTED_PROXY_CIDRS=172.16.0.0/12\n"
+        "ENABLE_HLS_TOKEN_VALIDATION=false\n"
+        "SESSION_SECRET=DOTENV_SENTINEL_SECRET\n"
+        "EMBY_API_KEY=DOTENV_SENTINEL_KEY\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "config.json").write_text(
+        '{"ENABLE_HLS_TOKEN_VALIDATION": false,"UNKNOWN_TOKEN": "CONFIG_SENTINEL_TOKEN"}',
+        encoding="utf-8",
+    )
+    before = _fingerprint(tmp_path)
+
+    code, output = run_preflight(
+        tmp_path,
+        target="production",
+        deployment="docker",
+        environ={"ENABLE_HLS_TOKEN_VALIDATION": "true", "SESSION_SECRET": "PROCESS_SECRET"},
+    )
+
+    assert code == 0
+    assert "ENABLE_HLS_TOKEN_VALIDATION=true (process environment)" in output
+    assert "BEHIND_PROXY=true (.env)" in output
+    assert "DOTENV_SENTINEL" not in output
+    assert "PROCESS_SECRET" not in output
+    assert "CONFIG_SENTINEL" not in output
+    assert _fingerprint(tmp_path) == before
+
+
+def test_preflight_names_production_actions_for_disabled_legacy_hls_and_proxy(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "config.json").write_text(
+        '{"ENABLE_HLS_TOKEN_VALIDATION": false}', encoding="utf-8"
+    )
+
+    code, output = run_preflight(
+        tmp_path,
+        target="production",
+        deployment="docker",
+        environ={},
+    )
+
+    assert code == 0
+    assert "REQUIRED ACTION: Set BEHIND_PROXY=true or BEHIND_PROXY=false" in output
+    assert "ENABLE_HLS_TOKEN_VALIDATION=false (legacy config.json)" in output
+    assert "REQUIRED ACTION: Set ENABLE_HLS_TOKEN_VALIDATION=true" in output
+    assert "SESSION_EXPIRY=1209600" in output
+
+
+def test_preflight_accepts_direct_deployment_and_reports_default_hls(tmp_path: Path) -> None:
+    (tmp_path / ".env").write_text("BEHIND_PROXY=false\nTRUSTED_PROXY_CIDRS=\n", encoding="utf-8")
+
+    code, output = run_preflight(
+        tmp_path,
+        target="production",
+        deployment="docker",
+        environ={},
+    )
+
+    assert code == 0
+    assert "BEHIND_PROXY=false (.env)" in output
+    assert "ENABLE_HLS_TOKEN_VALIDATION=true (default)" in output
+    assert "REQUIRED ACTION: Set TRUSTED_PROXY_CIDRS" not in output
+
+
+def test_preflight_fails_only_when_input_cannot_be_inspected(tmp_path: Path) -> None:
+    (tmp_path / "config.json").write_text("{broken", encoding="utf-8")
+
+    code, output = run_preflight(
+        tmp_path,
+        target="development",
+        deployment="docker",
+        environ={},
+    )
+
+    assert code == 1
+    assert "ERROR: config.json is not valid JSON" in output

--- a/tests/test_migration_preflight.py
+++ b/tests/test_migration_preflight.py
@@ -159,3 +159,44 @@ def test_source_runtime_versions_and_single_worker_can_pass(tmp_path: Path) -> N
     assert "Python 3.12.9 meets >=3.12,<3.13" in output
     assert "Node 24.1.0 meets >=20.19" in output
     assert "Application worker count is 1" in output
+
+
+def test_proxied_deployment_requires_trusted_cidrs(tmp_path: Path) -> None:
+    (tmp_path / ".env").write_text("BEHIND_PROXY=true\n", encoding="utf-8")
+
+    code, output = run_preflight(tmp_path, environ={})
+
+    assert code == 0
+    assert "REQUIRED ACTION: Set TRUSTED_PROXY_CIDRS" in output
+    assert "TRUSTED_PROXY_CIDRS=172.16.0.0/12" in output
+
+
+def test_development_reports_but_does_not_reject_disabled_hls(tmp_path: Path) -> None:
+    (tmp_path / "config.json").write_text(
+        '{"ENABLE_HLS_TOKEN_VALIDATION": false}', encoding="utf-8"
+    )
+
+    code, output = run_preflight(tmp_path, target="development", environ={})
+
+    assert code == 0
+    assert "ENABLE_HLS_TOKEN_VALIDATION=false (legacy config.json)" in output
+    assert "REQUIRED ACTION: Set ENABLE_HLS_TOKEN_VALIDATION=true" not in output
+
+
+def test_malformed_dotenv_fails_without_printing_its_contents(tmp_path: Path) -> None:
+    (tmp_path / ".env").write_text("SECRET_SENTINEL_WITHOUT_EQUALS\n", encoding="utf-8")
+
+    code, output = run_preflight(tmp_path, environ={})
+
+    assert code == 1
+    assert "ERROR: .env line 1 is malformed" in output
+    assert "SECRET_SENTINEL" not in output
+
+
+def test_non_file_legacy_config_is_an_inspection_error(tmp_path: Path) -> None:
+    (tmp_path / "config.json").mkdir()
+
+    code, output = run_preflight(tmp_path, environ={})
+
+    assert code == 1
+    assert "ERROR: config.json is not a regular file" in output

--- a/tests/test_migration_preflight.py
+++ b/tests/test_migration_preflight.py
@@ -124,3 +124,38 @@ def test_preflight_reports_malformed_rate_without_echoing_value(tmp_path: Path) 
     assert code == 0
     assert "ERROR: RATE_LIMIT_LOGIN has a malformed legacy value" in output
     assert "SECRET_SENTINEL" not in output
+
+
+def test_source_and_windows_requirements_are_explicit(tmp_path: Path) -> None:
+    code, output = run_preflight(
+        tmp_path,
+        target="development",
+        deployment="source",
+        environ={"WEB_CONCURRENCY": "2"},
+        platform_name="win32",
+        python_version=(3, 13, 0),
+        node_version=(20, 18, 0),
+    )
+
+    assert code == 0
+    assert "REQUIRED ACTION: Use Python >=3.12,<3.13" in output
+    assert "REQUIRED ACTION: Use Node >=20.19" in output
+    assert "REQUIRED ACTION: Run exactly one application worker" in output
+    assert "INFO: Windows support is best effort; Docker/Linux is recommended" in output
+
+
+def test_source_runtime_versions_and_single_worker_can_pass(tmp_path: Path) -> None:
+    code, output = run_preflight(
+        tmp_path,
+        target="development",
+        deployment="source",
+        environ={"UVICORN_WORKERS": "1"},
+        platform_name="linux",
+        python_version=(3, 12, 9),
+        node_version=(24, 1, 0),
+    )
+
+    assert code == 0
+    assert "Python 3.12.9 meets >=3.12,<3.13" in output
+    assert "Node 24.1.0 meets >=20.19" in output
+    assert "Application worker count is 1" in output

--- a/tests/test_migration_preflight.py
+++ b/tests/test_migration_preflight.py
@@ -97,3 +97,30 @@ def test_preflight_fails_only_when_input_cannot_be_inspected(tmp_path: Path) -> 
 
     assert code == 1
     assert "ERROR: config.json is not valid JSON" in output
+
+
+def test_preflight_reports_each_effective_legacy_rate_limit(tmp_path: Path) -> None:
+    (tmp_path / "config.json").write_text(
+        '{"RATE_LIMIT_API_CALLS": "77 per minute","RATE_LIMIT_CHAT": "4 per 3 seconds"}',
+        encoding="utf-8",
+    )
+
+    code, output = run_preflight(tmp_path, environ={})
+
+    assert code == 0
+    assert "RATE_LIMIT_API_CALLS=77 per minute (legacy config.json)" in output
+    assert "RATE_LIMIT_CHAT=4 per 3 seconds (legacy config.json)" in output
+    assert "RATE_LIMIT_LOGIN=10 per 15 minutes (default)" in output
+    assert output.count("this limit is enforced in 3.0") == 6
+
+
+def test_preflight_reports_malformed_rate_without_echoing_value(tmp_path: Path) -> None:
+    (tmp_path / "config.json").write_text(
+        '{"RATE_LIMIT_LOGIN": "SECRET_SENTINEL"}', encoding="utf-8"
+    )
+
+    code, output = run_preflight(tmp_path, environ={})
+
+    assert code == 0
+    assert "ERROR: RATE_LIMIT_LOGIN has a malformed legacy value" in output
+    assert "SECRET_SENTINEL" not in output

--- a/tests/test_production_config.py
+++ b/tests/test_production_config.py
@@ -133,6 +133,33 @@ class ProxyTopologyGateTests(unittest.TestCase):
         _config(APP_ENV="development", BEHIND_PROXY=None).validate_for_startup()
 
 
+class LegacyBootPrecedenceTests(unittest.TestCase):
+    def test_hls_validation_uses_environment_then_dotenv_then_legacy_then_default(
+        self,
+    ):
+        with tempfile.TemporaryDirectory() as raw_root:
+            root = Path(raw_root)
+            config_path = root / "config.json"
+
+            with mock.patch.dict(os.environ, {}, clear=True):
+                assert Config.from_env(root).ENABLE_HLS_TOKEN_VALIDATION is True
+
+                config_path.write_text(
+                    '{"ENABLE_HLS_TOKEN_VALIDATION": false}', encoding="utf-8"
+                )
+                assert Config.from_env(root).ENABLE_HLS_TOKEN_VALIDATION is False
+
+                (root / ".env").write_text(
+                    "ENABLE_HLS_TOKEN_VALIDATION=true\n", encoding="utf-8"
+                )
+                assert Config.from_env(root).ENABLE_HLS_TOKEN_VALIDATION is True
+
+                with mock.patch.dict(
+                    os.environ, {"ENABLE_HLS_TOKEN_VALIDATION": "false"}
+                ):
+                    assert Config.from_env(root).ENABLE_HLS_TOKEN_VALIDATION is False
+
+
 class ProductionConfigTests(unittest.TestCase):
     def test_production_rejects_missing_session_secret(self):
         with pytest.raises(ValueError, match="SESSION_SECRET"):

--- a/tests/test_production_config.py
+++ b/tests/test_production_config.py
@@ -144,19 +144,13 @@ class LegacyBootPrecedenceTests(unittest.TestCase):
             with mock.patch.dict(os.environ, {}, clear=True):
                 assert Config.from_env(root).ENABLE_HLS_TOKEN_VALIDATION is True
 
-                config_path.write_text(
-                    '{"ENABLE_HLS_TOKEN_VALIDATION": false}', encoding="utf-8"
-                )
+                config_path.write_text('{"ENABLE_HLS_TOKEN_VALIDATION": false}', encoding="utf-8")
                 assert Config.from_env(root).ENABLE_HLS_TOKEN_VALIDATION is False
 
-                (root / ".env").write_text(
-                    "ENABLE_HLS_TOKEN_VALIDATION=true\n", encoding="utf-8"
-                )
+                (root / ".env").write_text("ENABLE_HLS_TOKEN_VALIDATION=true\n", encoding="utf-8")
                 assert Config.from_env(root).ENABLE_HLS_TOKEN_VALIDATION is True
 
-                with mock.patch.dict(
-                    os.environ, {"ENABLE_HLS_TOKEN_VALIDATION": "false"}
-                ):
+                with mock.patch.dict(os.environ, {"ENABLE_HLS_TOKEN_VALIDATION": "false"}):
                     assert Config.from_env(root).ENABLE_HLS_TOKEN_VALIDATION is False
 
 

--- a/tests/test_rate_limiting.py
+++ b/tests/test_rate_limiting.py
@@ -72,7 +72,12 @@ def test_avatar_recovery_uses_shared_limiter_and_retry_after(tmp_path: Path):
 
     limited = asyncio.run(exercise())
     assert limited.status_code == 429
-    assert int(limited.headers["retry-after"]) > 0
+    retry_after = int(limited.headers["retry-after"])
+    assert limited.json() == {
+        "detail": f"Too many avatar recovery attempts. Try again in {retry_after} seconds.",
+        "code": "rate_limited",
+        "retry_after": retry_after,
+    }
     assert app.state.rate_limiter.active_bucket_count == 1
 
 
@@ -201,7 +206,12 @@ def test_general_api_limit_returns_429_with_retry_after():
 
     limited = asyncio.run(exercise())
     assert limited.status_code == 429
-    assert int(limited.headers["retry-after"]) > 0
+    retry_after = int(limited.headers["retry-after"])
+    assert limited.json() == {
+        "detail": f"Too many requests. Try again in {retry_after} seconds.",
+        "code": "rate_limited",
+        "retry_after": retry_after,
+    }
 
 
 def test_party_creation_uses_stricter_limit():
@@ -211,12 +221,40 @@ def test_party_creation_uses_stricter_limit():
     def create():
         return {"ok": True}
 
-    async def exercise() -> None:
+    async def exercise() -> httpx.Response:
         async with asgi_client(app) as client:
             assert (await client.post("/api/party/create")).status_code == 200
-            assert (await client.post("/api/party/create")).status_code == 429
+            return await client.post("/api/party/create")
 
-    asyncio.run(exercise())
+    limited = asyncio.run(exercise())
+    retry_after = int(limited.headers["retry-after"])
+    assert limited.json() == {
+        "detail": f"Too many party creation attempts. Try again in {retry_after} seconds.",
+        "code": "rate_limited",
+        "retry_after": retry_after,
+    }
+
+
+def test_party_join_limit_names_the_blocked_action():
+    app = _limited_app()
+
+    @app.post("/api/party/ABC123/join")
+    def join():
+        return {"ok": True}
+
+    async def exercise() -> httpx.Response:
+        async with asgi_client(app) as client:
+            assert (await client.post("/api/party/ABC123/join")).status_code == 200
+            assert (await client.post("/api/party/ABC123/join")).status_code == 200
+            return await client.post("/api/party/ABC123/join")
+
+    limited = asyncio.run(exercise())
+    retry_after = int(limited.headers["retry-after"])
+    assert limited.json() == {
+        "detail": f"Too many party join attempts. Try again in {retry_after} seconds.",
+        "code": "rate_limited",
+        "retry_after": retry_after,
+    }
 
 
 def test_rate_limit_honors_application_prefix():

--- a/tests/test_setup_mode.py
+++ b/tests/test_setup_mode.py
@@ -188,7 +188,15 @@ def test_stale_bootstrap_artefacts_are_ignored_and_removed(tmp_path: Path, monke
     config = Config.from_env(project_root=tmp_path)
     assert config.EMBY_API_KEY != "from-stale-file", "persisted file was still being read"
 
-    create_app(project_root=tmp_path, enable_update_check=False)
+    app = create_app(project_root=tmp_path, enable_update_check=False)
+    assert (data / "setup-token").exists(), "setup token removed before startup succeeded"
+    assert (data / "bootstrap.json").exists(), "bootstrap file removed before startup succeeded"
+
+    async def boot() -> None:
+        async with app.router.lifespan_context(app):
+            pass
+
+    asyncio.run(boot())
     assert not (data / "setup-token").exists(), "stale setup token left on disk"
     assert not (data / "bootstrap.json").exists(), "stale bootstrap file left on disk"
 

--- a/tests/test_setup_mode.py
+++ b/tests/test_setup_mode.py
@@ -193,8 +193,13 @@ def test_stale_bootstrap_artefacts_are_ignored_and_removed(tmp_path: Path, monke
     assert (data / "bootstrap.json").exists(), "bootstrap file removed before startup succeeded"
 
     async def boot() -> None:
+        assert (data / "setup-token").exists()
+        assert (data / "bootstrap.json").exists()
         async with app.router.lifespan_context(app):
-            pass
+            # Entering the lifespan means every fallible startup step
+            # completed and Starlette can begin serving requests.
+            assert not (data / "setup-token").exists()
+            assert not (data / "bootstrap.json").exists()
 
     asyncio.run(boot())
     assert not (data / "setup-token").exists(), "stale setup token left on disk"

--- a/tests/test_socket_connection_limit.py
+++ b/tests/test_socket_connection_limit.py
@@ -27,4 +27,10 @@ def test_socket_connection_attempts_return_rate_limited_reason(
 ) -> None:
     reason = asyncio.run(_exhaust_public_socket_limit(live_watchparty.url))
 
-    assert reason == {"message": "rate_limited"}
+    assert isinstance(reason, dict)
+    retry_after = reason["data"]["retry_after"]
+    assert retry_after > 0
+    assert reason == {
+        "message": f"Too many connection attempts. Try again in {retry_after} seconds.",
+        "data": {"code": "rate_limited", "retry_after": retry_after},
+    }

--- a/tests/test_socket_responsiveness.py
+++ b/tests/test_socket_responsiveness.py
@@ -67,3 +67,60 @@ def test_slow_emby_progress_does_not_block_independent_socket_control(
     live_watchparty,
 ) -> None:
     asyncio.run(_exercise_independent_controls(live_watchparty))
+
+
+async def _exercise_progress_coalescing(live_watchparty) -> None:
+    async with httpx.AsyncClient(base_url=live_watchparty.url) as client:
+        created = await client.post("/api/party/create", json={})
+        party_id = created.json()["party_id"]
+        await client.post(
+            f"/api/party/{party_id}/join",
+            json={"client_id": "progress-client", "display_name": "Alice"},
+        )
+        await client.post("/api/auth/login", json={"username": "Alice", "password": "password"})
+        cookie = "; ".join(f"{name}={value}" for name, value in client.cookies.items())
+        realtime = socketio.AsyncClient()
+        selected = asyncio.Event()
+
+        @realtime.on("video_selected")
+        async def video_selected(_data):
+            selected.set()
+
+        await realtime.connect(live_watchparty.url, headers={"Cookie": cookie})
+        try:
+            await realtime.emit(
+                "join_party",
+                {
+                    "party_id": party_id,
+                    "username": "Alice",
+                    "client_id": "progress-client",
+                },
+            )
+            await realtime.emit(
+                "select_video",
+                {"party_id": party_id, "item_id": "movie-1", "item_name": "Fake Movie"},
+            )
+            await asyncio.wait_for(selected.wait(), timeout=5)
+            live_watchparty.fake.state.requests.clear()
+
+            await realtime.emit("report_progress", {"party_id": party_id, "time": 12.0})
+            await realtime.emit("report_progress", {"party_id": party_id, "time": 34.0})
+
+            for _ in range(50):
+                state = (await client.get(f"/api/party/{party_id}/info")).json()
+                if state["playback_state"]["time"] == 34.0:
+                    break
+                await asyncio.sleep(0.02)
+            assert state["playback_state"]["time"] == 34.0
+            progress_reports = [
+                request
+                for request in live_watchparty.fake.state.requests
+                if request["path"] == "/emby/Sessions/Playing/Progress"
+            ]
+            assert len(progress_reports) == 1
+        finally:
+            await realtime.disconnect()
+
+
+def test_limited_progress_commits_latest_party_time(live_watchparty) -> None:
+    asyncio.run(_exercise_progress_coalescing(live_watchparty))

--- a/tests/test_startup_cleanup.py
+++ b/tests/test_startup_cleanup.py
@@ -1,4 +1,5 @@
 import asyncio
+import sqlite3
 from pathlib import Path
 
 import httpx
@@ -60,3 +61,27 @@ def test_partial_startup_closes_lifespan_http_transport(tmp_path: Path) -> None:
     transport = asyncio.run(_start_with_invalid_storage(root_file))
 
     assert transport.closed is True
+
+
+def test_failed_startup_keeps_stale_setup_artifacts_for_recovery(tmp_path: Path) -> None:
+    data = tmp_path / "data"
+    data.mkdir()
+    (data / "avatars.db").mkdir()
+    stale_paths = [data / "bootstrap.json", data / "setup-token"]
+    for path in stale_paths:
+        path.write_text("recoverable", encoding="utf-8")
+
+    app = create_app(
+        config=_config(),
+        project_root=tmp_path,
+        enable_update_check=False,
+    )
+
+    async def fail_startup() -> None:
+        with pytest.raises(sqlite3.OperationalError):
+            async with app.router.lifespan_context(app):
+                pass
+
+    asyncio.run(fail_startup())
+
+    assert all(path.read_text(encoding="utf-8") == "recoverable" for path in stale_paths)


### PR DESCRIPTION
## Summary

This finishes the remaining 2.1.x → 3.0 migration work from PR #45 and the beta feedback. The goal is to make upgrade problems visible instead of leaving users with a failed join, dead playback, or unclear startup error.

## Changes Made

- Added useful rate-limit errors for party creation, joining, session binding, login, avatar recovery, reconnects, background requests, and chat.
- Added a read-only migration preflight command that checks legacy settings, proxy/HLS requirements, enforced rate limits, runtime versions, paths to back up, health/readiness, and rollback preparation without printing secrets.
- Added fake-Emby playback coverage for playlists, segments, byte ranges, seeking, audio/subtitles, reconnects, host reload, iPhone native HLS, and cross-party denial.
- Updated the migration guide and operator examples with the preflight, validation, backup, and rollback workflow.
- Kept the existing 3.0 decisions intact: environment-only configuration, fail-closed production startup, one worker, async `httpx`, current HLS/session security, and iPhone/iPad-only native HLS forcing.

## Type of Change

- [x] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change (existing deployments need action)
- [x] Documentation
- [ ] Refactoring (no functional change)
- [ ] Dependencies

## Scope

- [x] This closes at most one issue, or is one self-contained feature
- [x] It targets the active integration branch (`3.0-dev`), not `main`

This is one migration-readiness pass: operator preflight, user-facing failure messages, regression coverage, and the documentation needed to use them.

<details>
<summary>Small commit breakdown (25 commits)</summary>

1. `16a1350 test: pin legacy boot-setting precedence`
2. `e052d90 fix: defer stale setup cleanup until startup`
3. `e148a19 fix: standardize HTTP rate-limit responses`
4. `231d596 fix: preserve HTTP rate-limit details in client`
5. `073d83c fix: surface limited party session binding`
6. `beda15c fix: show party creation rate-limit errors`
7. `58f97d6 fix: show admin login rate-limit errors`
8. `7e2b1f7 fix: show avatar rate-limit errors`
9. `6c4e454 fix: show background API rate limits`
10. `753f1c6 fix: return socket connection retry details`
11. `898fa8c fix: pause rate-limited socket reconnects`
12. `b244f90 fix: restore rate-limited chat drafts`
13. `9a3e09e feat: add read-only migration preflight`
14. `e29e002 feat: report enforced legacy rate limits`
15. `dad46d7 feat: check migration runtime requirements`
16. `028ac6b test: cover migration preflight edge cases`
17. `6260866 test: extend fake Emby stream fixtures`
18. `51b1cf2 test: add complete fake-Emby playback gate`
19. `7f70bf0 fix: surface party host login limits`
20. `1554b49 test: pin progress telemetry coalescing`
21. `4738f84 docs: add migration preflight workflow`
22. `35d5ff7 docs: expose preflight in operator examples`
23. `cbecb77 style: apply Python formatter`
24. `3d3b84c test: cover cross-tab party binding changes`
25. `31627bb test: pin setup cleanup to successful startup`

</details>

## Testing Done

**Running the existing suite is mandatory.** CI is the backstop, not your first run. From the repository root with `.venv` active (Python 3.12):

- [x] `python -m ruff check backend scripts tests`
- [x] `python -m ruff format --check backend scripts tests`
- [x] `python -m mypy`
- [x] `python -m pytest` — 132 passed
- [x] `python scripts/generate_socket_types.py --check`

From `frontend/`:

- [x] `npm run lint`
- [x] `npm run type-check`
- [x] `npm run test:unit` — 26 passed
- [x] `npm run build-only`
- [x] `npm run test:e2e` — 16 passed across Chromium and iPhone WebKit

Also ran `npm run test:playback-gate` separately (2 passed), both lock-resolution checks, Compose validation, a Docker build, and a single-worker container health check. GitHub Actions is green for validation, native iOS HLS, and Docker.

### Manual test report

**How I tested**

Windows 11, Docker Desktop, Chrome, direct connection, and the bundled fake Emby server. I built and started the image, checked `/api/health`, loaded the landing page, created a party, and opened the host-login flow. The automated Playwright run completed the fake login and playback paths.

**What this covered**

Container startup, one-worker launch, health response, landing page, party creation, host-login UI, and the browser paths exercised by the fake-Emby gate.

**What this did not cover**

A physical iPhone/iPad, real Emby media and credentials, reverse-proxy/appliance setups, or a multi-hour session. Those still need beta testing before release.

**Expected outcome**

The app starts with one worker, health returns 200, party creation and login remain usable, the playback gate completes without unexpected 401/403/429 responses, and migration/rate-limit failures show a useful message.

**Actual outcome**

Expected result. Local suites and GitHub Actions passed. The manual browser check reached the fake host-login flow; the automated gate completed the remaining fake-Emby playback checks.

## Documentation

- [x] `CHANGELOG.md` updated under `## [Unreleased]`, in the matching subsection
- [x] README, `.env.example` or `docker-compose.yml.example` updated, if configuration or usage changed
- [x] Generated files regenerated and committed, if their sources changed

## Screenshots

Not included. The changed UI is transient error/cooldown state and is covered by focused frontend tests plus Playwright.

## Related Issues

Follow-up to #45 and the Discord beta feedback.
