### PR TITLE
Harden appliance deployment, login failures, and config saves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,8 +54,8 @@ Run it **after** pointing your Compose file at a 3.0 image carrying this work an
 `scripts/generate_deployment_artifacts.py` renders it into the Compose example, `.env.example`,
 the environment reference, a CasaOS v2 manifest and a TrueNAS SCALE 24.10+ Custom App YAML.
 Each carries a schema hash, and CI fails the build if any of them drifts from the schema or
-stops parsing as Compose. Portainer imports the Compose file directly; Unraid keeps its
-separately maintained Community Apps template.
+stops parsing as Compose. Portainer imports the Compose file directly; the maintainer keeps
+Unraid's template in a separate repository, which Community Apps indexes through `TemplateURL`.
 
 The generated files are examples to copy, not files to run in place. They ship
 `APP_ENV=production` and leave `BEHIND_PROXY` and `SESSION_COOKIE_SECURE` commented out,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ diagnosis, updates, playback acceptance and full rollback, without ever deleting
 
 Three of these are defects a beta1 user can actually hit today.
 
+- **Mobile library browsing no longer hides its own navigation.** Opening a library on a phone now replaces the oversized party controls with a compact library bar, keeps search and the A-Z rail inside the viewport, and provides an always-visible route back to all libraries. Alphabet jumps now use Emby's full-library prefixes and `SortName` pagination instead of only the posters already loaded, so enabled letters work immediately on mobile and desktop without fetching every image first.
 - **A proxy error page no longer replaces the explanation.** When a reverse proxy answered with its own HTML error page, that page was printed in the party banner where the guidance should be. The fixed sentence now leads and any upstream detail follows in bounded parentheses.
 - **Turning rate limiting off now turns off chat's limit too.** Chat is the one limiter that ignored the master switch in **Admin -> Security**, so with limiting disabled it was still the only one firing, silently dropping messages. This release would have made that visible by disabling the composer, which is what surfaced it.
 - **A retry delay could be longer than the limit it belonged to.** A three-second window reported four seconds in `Retry-After`.

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ https://discord.gg/RWUpxq9xsA
 
 - **[Project wiki](https://github.com/Oratorian/emby-watchparty/wiki)** - hardware, deployment, troubleshooting, and FAQ
 - **[Migration guide](docs/Migration-HowTo.md)** - upgrade path from 2.1.x to 3.0
-- **[Appliance deployment](docs/deployment/appliance-migration.md)** - Compose, CasaOS, Portainer, and TrueNAS setup, diagnosis, update, and rollback; Unraid remains owned by its Community Apps repository
+- **[Appliance deployment](docs/deployment/appliance-migration.md)** - Compose, CasaOS, Portainer, and TrueNAS setup, diagnosis, update, and rollback; the maintainer's separate Unraid templates repository is indexed by Community Apps through `TemplateURL`
 - **[Socket.IO API](docs/SOCKET_API.md)** - developer reference for the Socket.IO event protocol
 - **OpenAPI reference** - `GET /docs` (Swagger UI) or `GET /redoc` on a running instance
 - **[CHANGELOG.md](CHANGELOG.md)** - per-release details including every fix and the reasoning behind it

--- a/SUMMARY-OF-CHANGES.md
+++ b/SUMMARY-OF-CHANGES.md
@@ -18,6 +18,35 @@ at beta1.
 
 ---
 
+### PR #59 follow-up: responsive library navigation
+
+Mobile library browsing had two independent failures. The party header kept a fixed
+80-pixel height while its controls wrapped into several rows, so those rows overlaid the
+library breadcrumb and made the route back to all libraries unreachable. The A-Z rail
+then built its enabled state from the current 50-item page and bucketed display `Name`,
+even though Emby orders libraries by `SortName`; letters outside that first page were
+therefore disabled on desktop and mobile.
+
+The mobile library-open state now uses a compact **All Libraries / current folder / Hide
+Library** bar and gives the library the remaining dynamic viewport height. Search, a
+responsive two-column poster grid and the sticky prefix rail stay within the viewport.
+Desktop keeps the full party header.
+
+Alphabet navigation now has an authenticated `/api/items/prefixes` boundary backed by
+Emby's `/Items/Prefixes`, plus an alphabetical item mode using `SortBy=SortName`.
+Selecting a prefix resolves its absolute offset through `NameLessThan`, fetches only that
+page, and keeps top and bottom sentinels so earlier and later pages remain reachable
+without loading the whole poster catalog. Season and episode views retain their numeric
+ordering. Prefix failures hide the shortcut without breaking ordinary browsing.
+
+Contract tests pin Emby scope, prefix forwarding and anchored offsets. Chromium proves a
+jump into an unloaded mixed-letter catalog and upward paging; iPhone WebKit proves the
+compact header, root navigation, visible search/prefix controls and overflow bounds. A
+checked local `docker-compose.yml` is also included for building and running this checkout
+with credentials supplied only through environment variables.
+
+---
+
 ### Appliance deployment
 
 **[dnordel](https://github.com/dnordel)**'s, contributed as [#58](https://github.com/Oratorian/emby-watchparty/pull/58): 16 commits over 20 files, +1627 / -204, making `deploy/schema.json` the single description of a deployment and rendering five artifacts from it with a hash stamp and a CI drift gate.

--- a/backend/src/config.py
+++ b/backend/src/config.py
@@ -8,6 +8,7 @@ Two tiers:
 """
 
 import contextlib
+import copy
 import ipaddress
 import json
 import os
@@ -631,10 +632,19 @@ class Config:
                         "reason": "boot setting; restart required",
                     }
                 )
-            changed, runtime_rejected = runtime.update_from_dict(payload)
-            rejected.extend(runtime_rejected)
-            if changed:
-                runtime.save()
+            # One request can update many scalar and collection fields. Keep a
+            # deep snapshot so any persistence failure restores all of them;
+            # callers must never observe a partially applied failed save.
+            original_values = copy.deepcopy(runtime.to_dict())
+            try:
+                changed, runtime_rejected = runtime.update_from_dict(payload)
+                rejected.extend(runtime_rejected)
+                if changed:
+                    runtime.save()
+            except Exception:
+                for key, value in original_values.items():
+                    setattr(runtime, key, value)
+                raise
             return changed, rejected
 
     def get_runtime_dict(self) -> dict:

--- a/backend/src/emby_client.py
+++ b/backend/src/emby_client.py
@@ -11,6 +11,10 @@ if TYPE_CHECKING:
     from backend.src.emby_gateway import EmbyGateway
 
 
+class EmbyUnavailableError(Exception):
+    """The configured Emby endpoint could not be reached."""
+
+
 class EmbyClient:
     def __init__(self, server_url: str, api_key: str, logger, gateway: EmbyGateway):
         self.server_url = server_url.rstrip("/")
@@ -66,7 +70,13 @@ class EmbyClient:
                 "username": user.get("Name", username),
                 "is_admin": bool((user.get("Policy") or {}).get("IsAdministrator")),
             }
-        except httpx.HTTPError as exc:
+        except httpx.RequestError as exc:
+            self.logger.error(
+                "Emby authentication failed: error=%s",
+                type(exc).__name__,
+            )
+            raise EmbyUnavailableError from exc
+        except httpx.HTTPStatusError as exc:
             self.logger.error(
                 "Emby authentication failed: error=%s",
                 type(exc).__name__,

--- a/backend/src/emby_client.py
+++ b/backend/src/emby_client.py
@@ -167,16 +167,9 @@ class EmbyClient:
             if item.get("Id")
         }
 
-    async def get_items(
-        self,
-        parent_id=None,
-        item_type=None,
-        recursive=False,
-        start_index=None,
-        limit=None,
-        access_token=None,
-        user_id=None,
-    ):
+    async def _resolve_item_scope(
+        self, parent_id, item_type, recursive, access_token, user_id
+    ) -> tuple[str | None, bool]:
         effective_type = item_type
         effective_recursive = recursive
         if parent_id and not item_type and not recursive:
@@ -184,7 +177,7 @@ class EmbyClient:
             collection_type = self._library_collection_types.get(user_id or "_anon_", {}).get(
                 parent_id
             )
-            mapping = {
+            collection_types = {
                 "movies": "Movie",
                 "tvshows": "Series",
                 "boxsets": "BoxSet",
@@ -192,30 +185,95 @@ class EmbyClient:
                 "homevideos": "Movie,Video,Photo",
                 "photos": "Movie,Video,Photo",
             }
-            if collection_type in mapping:
-                effective_type = mapping[collection_type]
+            effective_type = collection_types.get(collection_type) if collection_type else None
+            if effective_type:
                 effective_recursive = True
+        return effective_type, effective_recursive
+
+    async def get_items(
+        self,
+        parent_id=None,
+        item_type=None,
+        recursive=False,
+        start_index=None,
+        limit=None,
+        sort_mode="default",
+        anchor_prefix=None,
+        access_token=None,
+        user_id=None,
+    ):
+        effective_type, effective_recursive = await self._resolve_item_scope(
+            parent_id, item_type, recursive, access_token, user_id
+        )
         path = f"/emby/Users/{user_id}/Items" if user_id else "/emby/Items"
+        fields = (
+            "Overview,PrimaryImageAspectRatio,ProductionYear,IndexNumber,"
+            "ParentIndexNumber,SeriesId,SeasonId,UserData,MediaSourceCount"
+        )
+        if sort_mode == "alphabetical":
+            fields += ",SortName"
         params: dict[str, str | int] = {
             "Recursive": str(effective_recursive).lower(),
-            "Fields": (
-                "Overview,PrimaryImageAspectRatio,ProductionYear,IndexNumber,"
-                "ParentIndexNumber,SeriesId,SeasonId,UserData,MediaSourceCount"
+            "Fields": fields,
+            "SortBy": (
+                "SortName"
+                if sort_mode == "alphabetical"
+                else "ParentIndexNumber,IndexNumber,SortName"
             ),
-            "SortBy": "ParentIndexNumber,IndexNumber,SortName",
             "SortOrder": "Ascending",
         }
         if parent_id:
             params["ParentId"] = parent_id
         if effective_type:
             params["IncludeItemTypes"] = effective_type
-        if start_index is not None:
-            params["StartIndex"] = start_index
-        if limit is not None:
-            params["Limit"] = limit
         headers = self._headers(access_token, user_id)
         headers["Cache-Control"] = "no-cache"
+        if sort_mode == "alphabetical" and anchor_prefix:
+            count_params = {
+                **params,
+                "NameLessThan": anchor_prefix,
+                "StartIndex": 0,
+                "Limit": 1,
+            }
+            count_response = await self.gateway.get(path, headers=headers, params=count_params)
+            count_response.raise_for_status()
+            start_index = int(count_response.json().get("TotalRecordCount") or 0)
+        resolved_start_index = int(start_index or 0)
+        params["StartIndex"] = resolved_start_index
+        if limit is not None:
+            params["Limit"] = limit
         response = await self.gateway.get(path, headers=headers, params=params)
+        response.raise_for_status()
+        result = response.json()
+        result["StartIndex"] = resolved_start_index
+        return result
+
+    async def get_item_prefixes(
+        self,
+        parent_id=None,
+        item_type=None,
+        recursive=False,
+        access_token=None,
+        user_id=None,
+    ):
+        effective_type, effective_recursive = await self._resolve_item_scope(
+            parent_id, item_type, recursive, access_token, user_id
+        )
+        params: dict[str, str] = {
+            "UserId": user_id or "",
+            "Recursive": str(effective_recursive).lower(),
+            "SortBy": "SortName",
+            "SortOrder": "Ascending",
+        }
+        if parent_id:
+            params["ParentId"] = parent_id
+        if effective_type:
+            params["IncludeItemTypes"] = effective_type
+        response = await self.gateway.get(
+            "/emby/Items/Prefixes",
+            headers=self._headers(access_token, user_id),
+            params=params,
+        )
         response.raise_for_status()
         return response.json()
 

--- a/backend/src/routers/admin.py
+++ b/backend/src/routers/admin.py
@@ -26,6 +26,7 @@ from backend.src.dependencies import (
     is_admin_authenticated,
     scrub_legacy_admin_session,
 )
+from backend.src.emby_client import EmbyUnavailableError
 from backend.src.log_levels import apply_log_levels
 from backend.src.rate_limit import parse_rate, rate_limit_response
 from backend.src.schemas import (
@@ -78,7 +79,13 @@ async def admin_login(
                 f"Admin login rate-limited for IP {ip} (retry in {decision.retry_after}s)"
             )
             return rate_limit_response("login attempts", decision.retry_after)
-    auth = await emby_client.authenticate(body.username, body.password)
+    try:
+        auth = await emby_client.authenticate(body.username, body.password)
+    except EmbyUnavailableError:
+        return {
+            "success": False,
+            "message": "Emby server unavailable; verify EMBY_SERVER_URL",
+        }
     if not auth:
         return {"success": False, "message": "Invalid credentials"}
     try:

--- a/backend/src/routers/auth.py
+++ b/backend/src/routers/auth.py
@@ -19,6 +19,7 @@ from backend.src.dependencies import (
     get_sio,
     party_host_session_matches,
 )
+from backend.src.emby_client import EmbyUnavailableError
 from backend.src.schemas import (
     AuthStatusResponse,
     LoginRequest,
@@ -123,14 +124,20 @@ async def api_login(
     # backend restarts. Loud WARNING on every use so it never goes
     # unnoticed if accidentally left set in a non-dev environment.
     dev_user, dev_pw = _env_dev_host_creds(config)
-    if dev_user and dev_pw:
-        logger.warning(
-            f"Party {party_id}: host login auto-promoted via dev gate "
-            f"(EMBY_WATCHPARTY_X_DEV_HOST set, body credentials ignored)"
+    try:
+        if dev_user and dev_pw:
+            logger.warning(
+                f"Party {party_id}: host login auto-promoted via dev gate "
+                f"(EMBY_WATCHPARTY_X_DEV_HOST set, body credentials ignored)"
+            )
+            auth = await emby_client.authenticate(dev_user, dev_pw)
+        else:
+            auth = await emby_client.authenticate(body.username, body.password)
+    except EmbyUnavailableError:
+        return LoginResponse(
+            success=False,
+            message="Emby server unavailable; ask the operator to verify EMBY_SERVER_URL",
         )
-        auth = await emby_client.authenticate(dev_user, dev_pw)
-    else:
-        auth = await emby_client.authenticate(body.username, body.password)
     if not auth:
         return LoginResponse(success=False, message="Invalid Emby credentials")
 

--- a/backend/src/routers/library.py
+++ b/backend/src/routers/library.py
@@ -19,6 +19,7 @@ from backend.src.dependencies import (
 from backend.src.schemas import (
     ItemDetailsResponse,
     LibraryItemsResponse,
+    LibraryPrefixesResponse,
     StreamsResponse,
 )
 
@@ -49,6 +50,27 @@ async def api_libraries(
 
 
 @router.get(
+    "/items/prefixes",
+    response_model=LibraryPrefixesResponse,
+    responses=PARTY_UNLOCKED_RESPONSES,
+)
+async def api_item_prefixes(
+    parent_id: str | None = Query(None, alias="parentId"),
+    party_session: PartySession = Depends(require_party_unlocked),
+    emby_client=Depends(get_emby_client),
+):
+    access_token, user_id = _host_creds(party_session)
+    prefixes = await emby_client.get_item_prefixes(
+        parent_id=parent_id,
+        access_token=access_token,
+        user_id=user_id,
+    )
+    return {
+        "Prefixes": [row["Name"] for row in prefixes if isinstance(row, dict) and row.get("Name")]
+    }
+
+
+@router.get(
     "/items",
     response_model=LibraryItemsResponse,
     responses={
@@ -63,6 +85,8 @@ async def api_items(
     recursive: bool = False,
     start_index: int | None = Query(None, alias="startIndex"),
     limit: int | None = None,
+    sort_mode: str = Query("default", alias="sortMode", pattern="^(default|alphabetical)$"),
+    anchor_prefix: str | None = Query(None, alias="anchorPrefix", min_length=1, max_length=8),
     party_session: PartySession = Depends(require_party_unlocked),
     emby_client=Depends(get_emby_client),
 ):
@@ -75,6 +99,8 @@ async def api_items(
             recursive=recursive,
             start_index=start_index,
             limit=limit,
+            sort_mode=sort_mode,
+            anchor_prefix=anchor_prefix,
             access_token=access_token,
             user_id=user_id,
         )

--- a/backend/src/routers/party.py
+++ b/backend/src/routers/party.py
@@ -21,6 +21,7 @@ from backend.src.dependencies import (
     party_host_session_matches,
     scrub_legacy_admin_session,
 )
+from backend.src.emby_client import EmbyUnavailableError
 
 # Shared dev-host gate -- single source of truth lives in auth.py so the
 # env var name and value-parsing rules can never drift between modules.
@@ -202,7 +203,14 @@ async def create_party(
                 message="client_id is required",
             )
 
-        auth = await emby_client.authenticate(body.username, body.password)
+        try:
+            auth = await emby_client.authenticate(body.username, body.password)
+        except EmbyUnavailableError:
+            return CreatePartyResponse(
+                party_id="",
+                url="",
+                message="Emby server unavailable; ask the operator to verify EMBY_SERVER_URL",
+            )
         if not auth:
             return CreatePartyResponse(
                 party_id="",
@@ -325,7 +333,10 @@ async def join_party(
     dev_user, dev_pw = _env_dev_host_creds(config)
     is_host = party.host_client_id == body.client_id
     if dev_user and dev_pw and not party_manager.is_unlocked(party_id):
-        auth = await emby_client.authenticate(dev_user, dev_pw)
+        try:
+            auth = await emby_client.authenticate(dev_user, dev_pw)
+        except EmbyUnavailableError:
+            auth = None
         if auth:
             host_session_grant = secrets.token_urlsafe(32)
             party_manager.set_host(

--- a/backend/src/schemas.py
+++ b/backend/src/schemas.py
@@ -162,8 +162,13 @@ class LibraryItemsResponse(BaseModel):
 
     Items: list[LibraryItem] = []
     TotalRecordCount: int | None = None
+    StartIndex: int = 0
 
     model_config = ConfigDict(extra="allow")
+
+
+class LibraryPrefixesResponse(BaseModel):
+    Prefixes: list[str] = []
 
 
 class ItemDetailsResponse(BaseModel):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,27 @@
+services:
+  emby-watchparty:
+    build: .
+    image: emby-watchparty:local
+    container_name: emby-watchparty
+    environment:
+      WATCH_PARTY_BIND: 0.0.0.0
+      WATCH_PARTY_PORT: "5000"
+      APP_PREFIX: ${APP_PREFIX:-}
+      SESSION_EXPIRY: ${SESSION_EXPIRY:-86400}
+      EMBY_SERVER_URL: ${EMBY_SERVER_URL}
+      EMBY_API_KEY: ${EMBY_API_KEY}
+      APP_ENV: ${APP_ENV}
+      SESSION_SECRET: ${SESSION_SECRET}
+      SESSION_COOKIE_SECURE: ${SESSION_COOKIE_SECURE}
+      CORS_ALLOWED_ORIGINS: ${CORS_ALLOWED_ORIGINS}
+      TRUSTED_PROXY_CIDRS: ${TRUSTED_PROXY_CIDRS}
+      ENABLE_HLS_TOKEN_VALIDATION: ${ENABLE_HLS_TOKEN_VALIDATION:-true}
+      BEHIND_PROXY: ${BEHIND_PROXY}
+    ports:
+      - "127.0.0.1:5000:5000"
+    volumes:
+      - ./data:/app/data
+      - ./images/avatars:/app/images/avatars
+      - ./logs:/app/logs
+      - ./config.json:/app/config.json
+    restart: unless-stopped

--- a/docs/deployment/appliance-migration.md
+++ b/docs/deployment/appliance-migration.md
@@ -3,9 +3,10 @@
 Platform guides: [Compose](compose.md), [CasaOS](casaos.md), [Portainer](portainer.md), and
 [TrueNAS SCALE](truenas.md).
 
-Unraid is deliberately outside this artifact set. Its Community Apps repository owns the
-container template and exposes its flags through the Unraid WebUI; review that packaging in its
-own repository instead of generating a second template here.
+Unraid is deliberately outside this artifact set. The maintainer owns its separate templates
+repository; Community Apps indexes that repository through `TemplateURL` and exposes the template's
+flags through the Unraid WebUI. Review that packaging there instead of generating a second template
+here.
 
 ## Preflight interpretation
 

--- a/docs/research/appliance-platform-support.md
+++ b/docs/research/appliance-platform-support.md
@@ -32,8 +32,9 @@ support, not native compatibility test results.
   boot/appliance environment only. `config.json` remains mounted and backed up.
 - No TrueNAS catalog package: Custom App YAML is supported first; catalog maintenance ownership is
   unresolved.
-- No generated Unraid template: its Community Apps repository owns the template and WebUI-driven
-  flags. That packaging is reviewed separately instead of being duplicated by this schema.
+- No generated Unraid template: the maintainer owns the separate templates repository, which
+  Community Apps indexes through `TemplateURL`. Its WebUI-driven packaging is reviewed there
+  instead of being duplicated by this schema.
 - No universal `TRUSTED_PROXY_CIDRS` default: topology must be explicit and deployment-specific.
 - No CasaOS protected-secret or transactional-rollback claim: primary protocol defines packaging,
   not those guarantees.

--- a/frontend/e2e/fake-emby.spec.ts
+++ b/frontend/e2e/fake-emby.spec.ts
@@ -86,11 +86,64 @@ test('alphabet bar jumps across an unloaded library and can scroll back', async 
   const middle = page.getByRole('button', { name: 'Jump to M', exact: true })
   await expect(middle).toBeEnabled()
   await middle.click()
-  await expect(page.getByText('Middle Movie 0000', { exact: true })).toBeVisible()
+  const middleMovie = page.getByText('Middle Movie 0000', { exact: true })
+  await expect(middleMovie).toBeVisible()
+  await page.waitForTimeout(500)
+  expect(await middleMovie.evaluate((item) => {
+    const rect = item.getBoundingClientRect()
+    return rect.bottom > 0 && rect.top < window.innerHeight
+  })).toBe(true)
   expect(await page.locator('.item-card').count()).toBeLessThanOrEqual(100)
 
   await page.locator('.library-panel').evaluate((panel) => panel.scrollTo(0, 0))
   await expect(page.getByText('Alpha Movie 0050', { exact: true })).toBeVisible()
+
+  const zulu = page.getByText('Zulu Movie 0000', { exact: true })
+  await page.getByRole('button', { name: 'Jump to Z', exact: true }).click()
+  await expect(zulu).toBeVisible()
+  expect(await zulu.evaluate((item) => {
+    const rect = item.getBoundingClientRect()
+    return rect.bottom > 0 && rect.top < window.innerHeight
+  })).toBe(true)
+
+  const alpha = page.getByText('Alpha Movie 0000', { exact: true })
+  await page.getByRole('button', { name: 'Jump to A', exact: true }).click()
+  await expect(alpha).toBeVisible()
+  expect(await alpha.evaluate((item) => {
+    const rect = item.getBoundingClientRect()
+    return rect.bottom > 0 && rect.top < window.innerHeight
+  })).toBe(true)
+})
+
+test('legacy saved library state still enables alphabet navigation', async ({ page }) => {
+  await page.setViewportSize({ width: 910, height: 427 })
+  await page.goto('/')
+  await page.getByRole('button', { name: 'Create Party', exact: true }).click()
+  await page.getByPlaceholder('Your name (optional)').fill('Alice')
+  await page.getByRole('button', { name: 'Join', exact: true }).click()
+  await page.getByRole('main').getByRole(
+    'button', { name: 'Login to Become Host', exact: true },
+  ).click()
+  await page.getByPlaceholder('Emby username').fill('AlphabetLibrary')
+  await page.getByPlaceholder('Emby password').fill('password')
+  await page.getByRole('button', { name: 'Become Host', exact: true }).click()
+
+  await page.evaluate(() => localStorage.setItem(
+    'emby-watchparty-library-state',
+    JSON.stringify({
+      parentId: 'library-1',
+      breadcrumbs: [{ id: 'library-1', name: 'Movies' }],
+    }),
+  ))
+  await page.getByRole('button', { name: 'Hide Library', exact: true }).click()
+  await page.getByRole('banner').getByRole(
+    'button', { name: 'Browse Library', exact: true },
+  ).click()
+
+  await expect(page.getByText('Movies', { exact: true }).nth(1)).toBeVisible()
+  await expect(page.getByRole('button', { name: 'Jump to M', exact: true })).toBeEnabled()
+  const lastPrefix = page.getByRole('button', { name: 'Jump to Z', exact: true })
+  expect(await lastPrefix.evaluate((button) => button.getBoundingClientRect().bottom)).toBeLessThanOrEqual(427)
 })
 
 test('two browsers receive selection and synchronized controls', async ({ browser, page }) => {

--- a/frontend/e2e/fake-emby.spec.ts
+++ b/frontend/e2e/fake-emby.spec.ts
@@ -70,6 +70,29 @@ test('large library stays bounded and search remains responsive', async ({ page 
   await expect(page.getByText('Large Movie 0420', { exact: true })).toBeVisible()
 })
 
+test('alphabet bar jumps across an unloaded library and can scroll back', async ({ page }) => {
+  await page.goto('/')
+  await page.getByRole('button', { name: 'Create Party', exact: true }).click()
+  await page.getByPlaceholder('Your name (optional)').fill('Alice')
+  await page.getByRole('button', { name: 'Join', exact: true }).click()
+  await page.getByRole('main').getByRole(
+    'button', { name: 'Login to Become Host', exact: true },
+  ).click()
+  await page.getByPlaceholder('Emby username').fill('AlphabetLibrary')
+  await page.getByPlaceholder('Emby password').fill('password')
+  await page.getByRole('button', { name: 'Become Host', exact: true }).click()
+  await page.getByText('Movies', { exact: true }).click()
+
+  const middle = page.getByRole('button', { name: 'Jump to M', exact: true })
+  await expect(middle).toBeEnabled()
+  await middle.click()
+  await expect(page.getByText('Middle Movie 0000', { exact: true })).toBeVisible()
+  expect(await page.locator('.item-card').count()).toBeLessThanOrEqual(100)
+
+  await page.locator('.library-panel').evaluate((panel) => panel.scrollTo(0, 0))
+  await expect(page.getByText('Alpha Movie 0050', { exact: true })).toBeVisible()
+})
+
 test('two browsers receive selection and synchronized controls', async ({ browser, page }) => {
   await page.goto('/')
   await page.getByRole('button', { name: 'Create Party', exact: true }).click()

--- a/frontend/e2e/fake-emby.spec.ts
+++ b/frontend/e2e/fake-emby.spec.ts
@@ -146,6 +146,39 @@ test('legacy saved library state still enables alphabet navigation', async ({ pa
   expect(await lastPrefix.evaluate((button) => button.getBoundingClientRect().bottom)).toBeLessThanOrEqual(427)
 })
 
+test('compact desktop gives video full width and moves chat into a drawer', async ({ page }) => {
+  await page.setViewportSize({ width: 1138, height: 534 })
+  await page.goto('/')
+  await page.getByRole('button', { name: 'Create Party', exact: true }).click()
+  await page.getByPlaceholder('Your name (optional)').fill('Alice')
+  await page.getByRole('button', { name: 'Join', exact: true }).click()
+  await page.getByRole('main').getByRole(
+    'button', { name: 'Login to Become Host', exact: true },
+  ).click()
+  await page.getByPlaceholder('Emby username').fill('Alice')
+  await page.getByPlaceholder('Emby password').fill('password')
+  await page.getByRole('button', { name: 'Become Host', exact: true }).click()
+  await page.getByText('Movies', { exact: true }).click()
+  await page.getByText('Fake Movie', { exact: true }).click()
+
+  const chatToggle = page.getByRole('button', { name: 'Chat', exact: true })
+  await expect(chatToggle).toBeVisible()
+  await expect(page.locator('.chat-panel')).not.toBeInViewport()
+  expect(await page.locator('.video-area').evaluate((area) => area.getBoundingClientRect().width)).toBeGreaterThan(1120)
+  const videoSizing = await page.locator('.party-content').evaluate((content) => ({
+    contentHeight: content.getBoundingClientRect().height,
+    videoHeight: content.querySelector('video')?.getBoundingClientRect().height ?? 0,
+  }))
+  expect(videoSizing.videoHeight).toBeGreaterThan(videoSizing.contentHeight * 0.9)
+  expect(await page.getByRole('button', { name: 'Leave', exact: true }).evaluate(
+    (button) => button.getBoundingClientRect().right <= window.innerWidth,
+  )).toBe(true)
+
+  await chatToggle.click()
+  await expect(page.locator('.chat-panel')).toBeInViewport()
+  await expect(page.getByRole('button', { name: 'Close chat', exact: true })).toBeVisible()
+})
+
 test('two browsers receive selection and synchronized controls', async ({ browser, page }) => {
   await page.goto('/')
   await page.getByRole('button', { name: 'Create Party', exact: true }).click()

--- a/frontend/e2e/ios.spec.ts
+++ b/frontend/e2e/ios.spec.ts
@@ -22,6 +22,40 @@ test('iOS viewport supports safe areas and party controls remain usable', async 
   await expect(page.getByTitle('Close chat')).toBeVisible()
 })
 
+test('mobile library uses compact navigation and keeps alphabet controls visible', async ({ page }) => {
+  await page.goto('/')
+  await page.getByRole('button', { name: 'Create Party', exact: true }).tap()
+  await page.getByPlaceholder('Your name (optional)').fill('Alice')
+  await page.getByRole('button', { name: 'Join', exact: true }).tap()
+  await page.getByRole('main').getByRole(
+    'button', { name: 'Login to Become Host', exact: true },
+  ).tap()
+  await page.getByPlaceholder('Emby username').fill('AlphabetLibrary')
+  await page.getByPlaceholder('Emby password').fill('password')
+  await page.getByRole('button', { name: 'Become Host', exact: true }).tap()
+
+  const allLibraries = page.getByRole('button', { name: 'All Libraries', exact: true })
+  await expect(allLibraries).toBeVisible()
+  await expect(page.getByRole('button', { name: 'Hide Library', exact: true })).toBeVisible()
+  await page.getByText('Movies', { exact: true }).tap()
+
+  const middle = page.getByRole('button', { name: 'Jump to M', exact: true })
+  await expect(middle).toBeEnabled()
+  await expect(middle).toBeInViewport()
+  await expect(page.getByRole('button', { name: 'Search', exact: true })).toBeInViewport()
+  expect(await page.evaluate(() => document.documentElement.scrollWidth)).toBeLessThanOrEqual(
+    await page.evaluate(() => document.documentElement.clientWidth),
+  )
+
+  await allLibraries.tap()
+  await expect(page.getByText('Movies', { exact: true })).toBeVisible()
+  await page.getByRole('button', { name: 'Hide Library', exact: true }).tap()
+  await expect(page.getByRole('banner').getByRole(
+    'button', { name: 'Browse Library', exact: true },
+  )).toBeVisible()
+  await expect(allLibraries).toBeHidden()
+})
+
 test('@playback-gate iPhone WebKit selects native HLS from fake Emby', async ({ page }) => {
   await page.goto('/')
   await page.getByRole('button', { name: 'Create Party', exact: true }).tap()

--- a/frontend/e2e/ios.spec.ts
+++ b/frontend/e2e/ios.spec.ts
@@ -26,7 +26,12 @@ test('@playback-gate iPhone WebKit selects native HLS from fake Emby', async ({ 
   await page.goto('/')
   await page.getByRole('button', { name: 'Create Party', exact: true }).tap()
   await page.getByPlaceholder('Your name (optional)').fill('Alice')
+  const joined = page.waitForResponse(
+    (response) => response.request().method() === 'POST' && /\/api\/party\/[^/]+\/join$/.test(response.url()),
+  )
   await page.getByRole('button', { name: 'Join', exact: true }).tap()
+  expect((await joined).status()).toBe(200)
+  await expect(page.getByText('1 watching')).toBeVisible()
   await page.getByRole('main').getByRole(
     'button', { name: 'Login to Become Host', exact: true },
   ).tap()

--- a/frontend/e2e/playback-gate.spec.ts
+++ b/frontend/e2e/playback-gate.spec.ts
@@ -189,7 +189,9 @@ test('@playback-gate complete authenticated fake-Emby playback flow', async ({ b
   await other.getByPlaceholder('Emby username').fill('Mallory')
   await other.getByPlaceholder('Emby password').fill('password')
   await other.getByRole('button', { name: 'Become Host', exact: true }).click()
-  await expect(other.getByRole('button', { name: 'Browse Library' })).toBeVisible()
+  await expect(
+    other.getByRole('banner').getByRole('button', { name: 'Browse Library' }),
+  ).toBeVisible()
   const denied = await browserFetch(other, masterUrl, 'text')
   expect([401, 403]).toContain(denied.status)
 

--- a/frontend/e2e/playback-gate.spec.ts
+++ b/frontend/e2e/playback-gate.spec.ts
@@ -189,9 +189,7 @@ test('@playback-gate complete authenticated fake-Emby playback flow', async ({ b
   await other.getByPlaceholder('Emby username').fill('Mallory')
   await other.getByPlaceholder('Emby password').fill('password')
   await other.getByRole('button', { name: 'Become Host', exact: true }).click()
-  await expect(
-    other.getByRole('banner').getByRole('button', { name: 'Browse Library' }),
-  ).toBeVisible()
+  await expect(other.getByPlaceholder('Emby username')).toBeHidden()
   const denied = await browserFetch(other, masterUrl, 'text')
   expect([401, 403]).toContain(denied.status)
 

--- a/frontend/e2e/playback-gate.spec.ts
+++ b/frontend/e2e/playback-gate.spec.ts
@@ -33,6 +33,35 @@ async function expectOk(response: APIResponse, label: string): Promise<void> {
   expect(response.status(), `${label} returned ${response.status()}`).toBe(200)
 }
 
+interface BrowserFetchResult {
+  status: number
+  headers: Record<string, string>
+  text?: string
+  byteLength?: number
+}
+
+async function browserFetch(
+  page: Page,
+  url: string,
+  bodyType: 'text' | 'bytes',
+  headers: Record<string, string> = {},
+): Promise<BrowserFetchResult> {
+  return page.evaluate(async ({ requestUrl, responseType, requestHeaders }) => {
+    const response = await fetch(requestUrl, { headers: requestHeaders })
+    const result: BrowserFetchResult = {
+      status: response.status,
+      headers: Object.fromEntries(response.headers.entries()),
+    }
+    if (responseType === 'text') result.text = await response.text()
+    else result.byteLength = (await response.arrayBuffer()).byteLength
+    return result
+  }, { requestUrl: url, responseType: bodyType, requestHeaders: headers })
+}
+
+function expectBrowserOk(response: BrowserFetchResult, label: string): void {
+  expect(response.status, `${label} returned ${response.status}`).toBe(200)
+}
+
 test('@playback-gate complete authenticated fake-Emby playback flow', async ({ browser, page }) => {
   const watchedFailures: string[] = []
   const masterRequests: string[] = []
@@ -87,20 +116,20 @@ test('@playback-gate complete authenticated fake-Emby playback flow', async ({ b
 
   await expect.poll(() => masterRequests.length).toBeGreaterThan(0)
   const masterUrl = masterRequests.at(-1)!
-  const master = await page.request.get(masterUrl)
-  await expectOk(master, 'authenticated HLS master playlist')
-  expect(master.headers()['content-type']).toContain('mpegurl')
-  const variantUrl = new URL(mediaUri(await master.text()), masterUrl).href
-  const variant = await page.request.get(variantUrl)
-  await expectOk(variant, 'authenticated HLS media playlist')
-  const segmentUrl = new URL(mediaUri(await variant.text()), variantUrl).href
-  const segment = await page.request.get(segmentUrl)
-  await expectOk(segment, 'authenticated HLS segment')
-  expect((await segment.body()).byteLength).toBeGreaterThan(0)
-  const range = await page.request.get(segmentUrl, { headers: { Range: 'bytes=0-17' } })
-  expect(range.status()).toBe(206)
-  expect(range.headers()['content-range']).toBe('bytes 0-17/168260')
-  expect((await range.body()).byteLength).toBe(18)
+  const master = await browserFetch(page, masterUrl, 'text')
+  expectBrowserOk(master, 'authenticated HLS master playlist')
+  expect(master.headers['content-type']).toContain('mpegurl')
+  const variantUrl = new URL(mediaUri(master.text!), masterUrl).href
+  const variant = await browserFetch(page, variantUrl, 'text')
+  expectBrowserOk(variant, 'authenticated HLS media playlist')
+  const segmentUrl = new URL(mediaUri(variant.text!), variantUrl).href
+  const segment = await browserFetch(page, segmentUrl, 'bytes')
+  expectBrowserOk(segment, 'authenticated HLS segment')
+  expect(segment.byteLength).toBeGreaterThan(0)
+  const range = await browserFetch(page, segmentUrl, 'bytes', { Range: 'bytes=0-17' })
+  expect(range.status).toBe(206)
+  expect(range.headers['content-range']).toBe('bytes 0-17/168260')
+  expect(range.byteLength).toBe(18)
 
   const audio = page.getByLabel('Audio')
   await expect(audio.locator('option')).toHaveCount(2)
@@ -152,20 +181,17 @@ test('@playback-gate complete authenticated fake-Emby playback flow', async ({ b
   await expect(page.locator('video#videoElement')).toHaveAttribute('title', 'Fake Movie')
 
   const otherContext = await browser.newContext()
-  const created = await otherContext.request.post('/api/party/create', { data: {} })
-  expect(created.status()).toBe(200)
-  const otherParty = (await created.json()).party_id as string
-  const joined = await otherContext.request.post(`/api/party/${otherParty}/join`, {
-    data: { client_id: 'cross-party-client', display_name: 'Mallory' },
-  })
-  expect(joined.status()).toBe(200)
-  const otherLogin = await otherContext.request.post('/api/auth/login', {
-    data: { username: 'Mallory', password: 'password' },
-  })
-  expect(otherLogin.status()).toBe(200)
-  expect((await otherLogin.json()).success).toBe(true)
-  const denied = await otherContext.request.get(masterUrl)
-  expect([401, 403]).toContain(denied.status())
+  const other = await otherContext.newPage()
+  await createAndJoin(other, 'Mallory')
+  await other.getByRole('main').getByRole(
+    'button', { name: 'Login to Become Host', exact: true },
+  ).click()
+  await other.getByPlaceholder('Emby username').fill('Mallory')
+  await other.getByPlaceholder('Emby password').fill('password')
+  await other.getByRole('button', { name: 'Become Host', exact: true }).click()
+  await expect(other.getByRole('button', { name: 'Browse Library' })).toBeVisible()
+  const denied = await browserFetch(other, masterUrl, 'text')
+  expect([401, 403]).toContain(denied.status)
 
   expect(watchedFailures, 'unexpected auth, rate-limit, or cross-party browser failures').toEqual([])
   await otherContext.close()

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -37,6 +37,9 @@ export default defineConfig({
         EMBY_SERVER_URL: 'http://127.0.0.1:5012',
         EMBY_API_KEY: 'e2e-key',
         SESSION_SECRET: 'playwright-session-secret-at-least-32-characters',
+        // E2E runs over plain loopback HTTP. Override any operator `.env`
+        // value so WebKit does not receive a Secure cookie it cannot send.
+        SESSION_COOKIE_SECURE: 'false',
         CORS_ALLOWED_ORIGINS: 'http://127.0.0.1:4173',
         E2E_BACKEND_PORT: '5011',
       },

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -92,6 +92,7 @@ export interface LibraryItem {
   Type: string
   Overview?: string
   RunTimeTicks?: number
+  SortName?: string
   MediaSourceCount?: number
   UserData?: {
     PlaybackPositionTicks?: number
@@ -102,6 +103,10 @@ export interface LibraryItem {
 export interface LibraryResponse {
   Items: LibraryItem[]
   TotalRecordCount?: number
+  StartIndex?: number
+}
+export interface LibraryPrefixesResponse {
+  Prefixes: string[]
 }
 export interface PartyResponse extends SuccessResponse {
   party_id?: string
@@ -268,6 +273,10 @@ export const api = {
     ).toString()
     return apiFetch<LibraryResponse>(`/api/items?${qs}`, { signal })
   },
+  itemPrefixes: (parentId: string, signal?: AbortSignal) => apiFetch<LibraryPrefixesResponse>(
+    `/api/items/prefixes?${new URLSearchParams({ parentId }).toString()}`,
+    { signal },
+  ),
   search: (q: string, signal?: AbortSignal) => apiFetch<LibraryResponse>(
     `/api/search?q=${encodeURIComponent(q)}`, { signal },
   ),

--- a/frontend/src/components/LibraryBrowser.vue
+++ b/frontend/src/components/LibraryBrowser.vue
@@ -303,7 +303,21 @@ function loadLibraryState(): LibraryState | null {
     if (!raw) return null
     const parsed = JSON.parse(raw)
     if (!parsed?.parentId || !Array.isArray(parsed?.breadcrumbs)) return null
-    return parsed as LibraryState
+    const breadcrumbs = parsed.breadcrumbs as Breadcrumb[]
+
+    // Saved states written before breadcrumb types were persisted contain
+    // only the top-level library id/name. That location is necessarily an
+    // Emby CollectionFolder, so migrate it instead of silently disabling
+    // alphabetical mode (and therefore the entire prefix rail). Deeper
+    // untyped paths are ambiguous (Folder, Series, or Season); discard those
+    // restore targets rather than applying alphabetical ordering to episodes.
+    const rootBreadcrumb = breadcrumbs[0]
+    if (breadcrumbs.length === 1 && rootBreadcrumb && !rootBreadcrumb.type) {
+      breadcrumbs[0] = { ...rootBreadcrumb, type: 'CollectionFolder' }
+    }
+    if (!breadcrumbs.at(-1)?.type) return null
+
+    return { parentId: parsed.parentId, breadcrumbs }
   } catch {
     return null
   }
@@ -343,7 +357,11 @@ async function jumpToLetter(letter: string) {
   if (!firstItem) return
   browserRoot.value
     ?.querySelector<HTMLElement>(`[data-item-id="${CSS.escape(firstItem.Id)}"]`)
-    ?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+    // A smooth scroll races the top sentinel: it can prepend several pages
+    // while the animation is still moving, leaving the viewport before (or
+    // halfway through) the selected prefix. Land synchronously so prepend
+    // scroll-height compensation keeps this exact first item pinned.
+    ?.scrollIntoView({ behavior: 'auto', block: 'start' })
 }
 
 // Compute the card's aspect ratio from Emby's PrimaryImageAspectRatio.
@@ -794,10 +812,13 @@ onUnmounted(() => {
 .alphabet-bar {
   position: sticky;
   top: 0;
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-auto-flow: row;
+  grid-auto-rows: minmax(0, 1fr);
   align-items: center;
-  gap: 1px;
+  gap: clamp(0px, 0.15dvh, 1px);
+  height: min(467px, calc(100dvh - 200px));
+  min-height: 0;
   padding: 4px 2px;
   background: var(--bg-surface);
   border: 1px solid var(--border-subtle);
@@ -812,10 +833,11 @@ onUnmounted(() => {
   border: 0;
   padding: 0;
   width: 18px;
-  height: 16px;
+  height: 100%;
+  min-height: 0;
   display: grid;
   place-items: center;
-  font-size: 10px;
+  font-size: clamp(7px, 1.2dvh, 10px);
   font-weight: 600;
   color: var(--accent-primary);
   font-family: var(--font-sans);
@@ -1087,8 +1109,9 @@ onUnmounted(() => {
 
   .alphabet-bar {
     right: 0;
-    max-height: calc(100dvh - 170px - env(safe-area-inset-top));
-    overflow-y: auto;
+    height: min(521px, calc(100dvh - 180px - env(safe-area-inset-top)));
+    max-height: none;
+    overflow: hidden;
     scrollbar-width: none;
   }
 
@@ -1098,8 +1121,7 @@ onUnmounted(() => {
 
   .alphabet-letter {
     width: 20px;
-    height: 18px;
-    flex-shrink: 0;
+    height: 100%;
   }
 }
 </style>

--- a/frontend/src/components/LibraryBrowser.vue
+++ b/frontend/src/components/LibraryBrowser.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="library-browser">
+  <div ref="browserRoot" class="library-browser">
       <div class="panel-header">
         <div class="breadcrumbs">
           <span class="crumb" @click="goToRoot">Libraries</span>
@@ -33,8 +33,11 @@
 
       <div v-else class="library-content">
         <div class="items-grid">
+          <div v-if="hasPrevious" ref="topSentinel" class="sentinel sentinel-top">
+            <span v-if="loadingPrevious">Loading earlier titles...</span>
+          </div>
           <div
-            v-for="item in displayedItems"
+            v-for="item in items"
             :key="item.Id"
             :data-item-id="item.Id"
             class="item-card"
@@ -92,27 +95,18 @@
           </div>
         </div>
 
-        <!-- iOS-style A-Z jump bar. Only renders when the list is long
-             enough that scrolling becomes a chore (>=30 items). Dimmed
-             letters have no matching items and are not clickable.
-             Left-click jumps to the letter; right-click toggles a
-             filter that hides everything except items starting with
-             that letter (right-click the same letter again to clear). -->
+        <!-- iOS-style prefix jump bar. Availability comes from Emby,
+             not the currently loaded page, so every server prefix works
+             immediately in a paginated library. -->
         <div v-if="showAlphabetBar" class="alphabet-bar" aria-label="Jump to letter">
           <button
-            v-for="letter in ALPHABET"
+            v-for="letter in displayedPrefixes"
             :key="letter"
             class="alphabet-letter"
-            :class="{
-              dim: !alphabetIndex.has(letter),
-              active: filteredLetter === letter,
-            }"
-            :disabled="!alphabetIndex.has(letter)"
+            :class="{ dim: !availablePrefixes.has(letter) }"
+            :disabled="!availablePrefixes.has(letter)"
             @click="jumpToLetter(letter)"
-            @contextmenu="toggleFilterLetter(letter, $event)"
-            :aria-label="filteredLetter === letter
-              ? `Showing only ${letter}; right-click to clear`
-              : `Jump to ${letter}; right-click to show only ${letter}`"
+            :aria-label="`Jump to ${letter}`"
           >
             {{ letter }}
           </button>
@@ -180,6 +174,7 @@ interface EmbyItem {
   ProductionYear?: number
   Overview?: string
   RunTimeTicks?: number
+  SortName?: string
   UserData?: {
     PlaybackPositionTicks?: number
     PlayedPercentage?: number
@@ -222,20 +217,28 @@ function playedLabel(item: EmbyItem): string | null {
 interface Breadcrumb {
   id: string
   name: string
+  type?: string
 }
 
 const emit = defineEmits<{
   'select-video': [item: EmbyItem]
+  'navigation-change': [label: string]
 }>()
 
+const browserRoot = ref<HTMLElement | null>(null)
 const loading = ref(false)
 const loadingMore = ref(false)
+const loadingPrevious = ref(false)
 const items = ref<EmbyItem[]>([])
 const breadcrumbs = ref<Breadcrumb[]>([])
 const searchQuery = ref('')
 const isSearching = ref(false)
 const hasMore = ref(false)
+const hasPrevious = ref(false)
+const loadedStartIndex = ref(0)
+const totalRecordCount = ref(0)
 const currentParentId = ref<string | null>(null)
+const currentParentType = ref<string | null>(null)
 const PAGE_SIZE = 50
 
 // Per-tab nav token. Bumped on every navigation (root, breadcrumb,
@@ -315,68 +318,32 @@ function imageUrl(id: string): string {
   return api.imageUrl(id, 'Primary', { maxWidth: 320, maxHeight: 480, quality: 90 })
 }
 
-// First letter of each item's Name, bucketed for the A-Z jump bar.
-// Returns '#' for digits/symbols so they cluster under one button
-// rather than spreading across letters that don't exist. Articles are
-// already stripped server-side via Emby's SortName (`The Matrix` is
-// sorted as `Matrix`) so the on-screen card order matches the letter
-// the user reaches for.
-function bucketLetter(name: string): string {
-  const first = (name || '').trim().charAt(0).toUpperCase()
-  return /^[A-Z]$/.test(first) ? first : '#'
-}
-
-// Map letter -> first item Id starting with that letter. Always built
-// against the FULL items list (not the filtered view below) so the
-// jump bar can navigate to any letter even while a filter is active.
-const alphabetIndex = computed(() => {
-  const map = new Map<string, string>()
-  for (const item of items.value) {
-    const letter = bucketLetter(item.Name)
-    if (!map.has(letter)) {
-      map.set(letter, item.Id)
-    }
-  }
-  return map
+const availablePrefixes = ref<Set<string>>(new Set())
+const alphabeticalMode = computed(() => (
+  currentParentType.value === 'CollectionFolder' || currentParentType.value === 'Folder'
+))
+const displayedPrefixes = computed(() => {
+  const extras = [...availablePrefixes.value]
+    .filter((prefix) => !ALPHABET.includes(prefix))
+    .sort((a, b) => a.localeCompare(b))
+  return [...ALPHABET, ...extras]
 })
+const showAlphabetBar = computed(() => (
+  alphabeticalMode.value
+  && totalRecordCount.value >= ALPHABET_BAR_MIN_ITEMS
+  && availablePrefixes.value.size > 0
+))
 
-const showAlphabetBar = computed(() => items.value.length >= ALPHABET_BAR_MIN_ITEMS)
-
-// Right-click on a letter restricts the visible grid to items whose
-// names start with that letter. null = no filter, show everything.
-// Cleared automatically whenever the underlying items list is replaced
-// (folder navigation, fresh search, etc.) so a filter never carries
-// over into an unrelated view.
-const filteredLetter = ref<string | null>(null)
-
-const displayedItems = computed(() => {
-  if (!filteredLetter.value) return items.value
-  return items.value.filter((item) => bucketLetter(item.Name) === filteredLetter.value)
-})
-
-function jumpToLetter(letter: string) {
-  // Left-click always shows the full list and jumps to the letter --
-  // otherwise scrolling to letter "A" while filtered to "M" would
-  // silently no-op because A's first item is currently filtered out.
-  filteredLetter.value = null
-  const targetId = alphabetIndex.value.get(letter)
-  if (!targetId) return
-  // Defer the scroll one tick so any DOM updates from clearing the
-  // filter have flushed before we look up the target card.
-  nextTick(() => {
-    const el = document.querySelector(`[data-item-id="${targetId}"]`)
-    if (el) {
-      el.scrollIntoView({ behavior: 'smooth', block: 'start' })
-    }
-  })
-}
-
-function toggleFilterLetter(letter: string, event: MouseEvent) {
-  // Block the native browser context menu -- right-click on the
-  // alphabet bar is "filter" in this UI, not "inspect element".
-  event.preventDefault()
-  if (!alphabetIndex.value.has(letter)) return
-  filteredLetter.value = filteredLetter.value === letter ? null : letter
+async function jumpToLetter(letter: string) {
+  if (!currentParentId.value || !availablePrefixes.value.has(letter)) return
+  bumpNavToken(`jumpToLetter:${letter}`)
+  await fetchItems(currentParentId.value, false, false, letter)
+  await nextTick()
+  const firstItem = items.value[0]
+  if (!firstItem) return
+  browserRoot.value
+    ?.querySelector<HTMLElement>(`[data-item-id="${CSS.escape(firstItem.Id)}"]`)
+    ?.scrollIntoView({ behavior: 'smooth', block: 'start' })
 }
 
 // Compute the card's aspect ratio from Emby's PrimaryImageAspectRatio.
@@ -407,7 +374,13 @@ async function goToRoot() {
   isSearching.value = false
   searchQuery.value = ''
   hasMore.value = false
+  hasPrevious.value = false
+  loadedStartIndex.value = 0
+  totalRecordCount.value = 0
+  availablePrefixes.value = new Set()
   currentParentId.value = null
+  currentParentType.value = null
+  emit('navigation-change', 'Libraries')
   await fetchLibraries()
 }
 
@@ -415,8 +388,10 @@ async function goToCrumb(index: number) {
   bumpNavToken(`goToCrumb:${index}`)
   const crumb = breadcrumbs.value[index]
   breadcrumbs.value = breadcrumbs.value.slice(0, index + 1)
+  currentParentType.value = crumb?.type ?? null
   isSearching.value = false
   searchQuery.value = ''
+  emit('navigation-change', crumb?.name ?? 'Libraries')
   await fetchItems(crumb!.id)
 }
 
@@ -430,8 +405,12 @@ async function fetchLibraries() {
       return
     }
     items.value = data.Items ?? data ?? []
+    totalRecordCount.value = data.TotalRecordCount ?? items.value.length
+    loadedStartIndex.value = 0
+    hasPrevious.value = false
+    hasMore.value = false
     clearLibraryState()
-    filteredLetter.value = null
+    availablePrefixes.value = new Set()
   } catch {
     if (myToken !== navToken) return
     items.value = []
@@ -454,25 +433,59 @@ const displayableTypes = new Set([
   'MusicAlbum', 'MusicArtist', 'Audio',
 ])
 
-async function fetchItems(parentId: string, append = false): Promise<'ok' | 'stale' | 'error'> {
+async function fetchPrefixes(parentId: string) {
+  if (!alphabeticalMode.value) {
+    availablePrefixes.value = new Set()
+    return
+  }
+  try {
+    const data = await api.itemPrefixes(parentId, navigationSignal())
+    availablePrefixes.value = new Set(
+      (data.Prefixes ?? []).map((prefix) => prefix.trim().toUpperCase()).filter(Boolean),
+    )
+  } catch {
+    availablePrefixes.value = new Set()
+  }
+}
+
+async function fetchItems(
+  parentId: string,
+  append = false,
+  prepend = false,
+  anchorPrefix?: string,
+): Promise<'ok' | 'stale' | 'error'> {
   // Append-paths inherit the current nav token (they're a continuation
   // of the same nav); fresh navigations get a new token via the caller
   // (handleItemClick / goToCrumb / etc.) before fetchItems runs.
   const myToken = navToken
-  if (append) {
+  if (prepend) {
+    loadingPrevious.value = true
+  } else if (append) {
     loadingMore.value = true
   } else {
     loading.value = true
     items.value = []
     currentParentId.value = parentId
-    // A fresh navigation means a fresh A-Z scope; the previous
-    // letter-filter shouldn't carry over into an unrelated view.
-    filteredLetter.value = null
+    hasPrevious.value = false
+    hasMore.value = false
   }
   try {
-    const startIndex = append ? items.value.length : 0
+    const previousPanel = browserRoot.value?.closest<HTMLElement>('.library-panel')
+    const previousScrollHeight = previousPanel?.scrollHeight ?? 0
+    const startIndex = prepend
+      ? Math.max(0, loadedStartIndex.value - PAGE_SIZE)
+      : append
+        ? loadedStartIndex.value + items.value.length
+        : 0
+    const params: Record<string, string | number | boolean> = {
+      parentId,
+      startIndex,
+      limit: PAGE_SIZE,
+      sortMode: alphabeticalMode.value ? 'alphabetical' : 'default',
+    }
+    if (anchorPrefix) params.anchorPrefix = anchorPrefix
     const data = await api.items(
-      { parentId, startIndex, limit: PAGE_SIZE },
+      params,
       navigationSignal(),
     )
     if (myToken !== navToken) {
@@ -496,13 +509,23 @@ async function fetchItems(parentId: string, append = false): Promise<'ok' | 'sta
     const newItems = hasDisplayable
       ? rawItems.filter((it) => displayableTypes.has(it.Type))
       : rawItems
-    if (append) {
+    const responseStart = data.StartIndex ?? startIndex
+    if (prepend) {
+      items.value.unshift(...newItems)
+      loadedStartIndex.value = responseStart
+      await nextTick()
+      if (previousPanel) {
+        previousPanel.scrollTop += previousPanel.scrollHeight - previousScrollHeight
+      }
+    } else if (append) {
       items.value.push(...newItems)
     } else {
       items.value = newItems
+      loadedStartIndex.value = responseStart
     }
-    const totalCount = data.TotalRecordCount ?? newItems.length
-    hasMore.value = items.value.length < totalCount
+    totalRecordCount.value = data.TotalRecordCount ?? newItems.length
+    hasPrevious.value = loadedStartIndex.value > 0
+    hasMore.value = loadedStartIndex.value + items.value.length < totalRecordCount.value
     // Only pin the current location as the restore target when the
     // response actually contained items. An empty response is ambiguous
     // with a mid-scan Emby state (files replaced, indexer hasn't caught
@@ -510,16 +533,17 @@ async function fetchItems(parentId: string, append = false): Promise<'ok' | 'sta
     // empty grid on every reload until the user manually navigates
     // elsewhere. In-session navigation into an empty folder still
     // works -- it just doesn't get persisted.
-    if (!append && !isSearching.value && newItems.length > 0) saveLibraryState()
+    if (!append && !prepend && !isSearching.value && newItems.length > 0) saveLibraryState()
+    if (!append && !prepend && !anchorPrefix) await fetchPrefixes(parentId)
   } catch {
     if (myToken !== navToken) return 'stale'
-    if (!append) items.value = []
-    hasMore.value = false
+    if (!append && !prepend) items.value = []
     return 'error'
   } finally {
     if (myToken === navToken) {
       loading.value = false
       loadingMore.value = false
+      loadingPrevious.value = false
     }
   }
   return 'ok'
@@ -530,6 +554,11 @@ function loadMore() {
   fetchItems(currentParentId.value, true)
 }
 
+function loadPrevious() {
+  if (loadingPrevious.value || !hasPrevious.value || !currentParentId.value) return
+  fetchItems(currentParentId.value, false, true)
+}
+
 async function doSearch() {
   const q = searchQuery.value.trim()
   if (!q) return
@@ -537,9 +566,12 @@ async function doSearch() {
   loading.value = true
   isSearching.value = true
   breadcrumbs.value = []
-  filteredLetter.value = null
   hasMore.value = false
+  hasPrevious.value = false
+  availablePrefixes.value = new Set()
   currentParentId.value = null
+  currentParentType.value = null
+  emit('navigation-change', 'Search results')
   try {
     const data = await api.search(q, navigationSignal())
     if (myToken !== navToken) {
@@ -547,6 +579,8 @@ async function doSearch() {
       return
     }
     items.value = data.Items ?? data ?? []
+    totalRecordCount.value = data.TotalRecordCount ?? items.value.length
+    loadedStartIndex.value = 0
   } catch {
     if (myToken !== navToken) return
     items.value = []
@@ -569,33 +603,44 @@ async function handleItemClick(item: EmbyItem) {
 
   if (browsableTypes.has(item.Type)) {
     bumpNavToken(`handleItemClick:${item.Type}:${item.Id}`)
-    breadcrumbs.value.push({ id: item.Id, name: item.Name })
+    breadcrumbs.value.push({ id: item.Id, name: item.Name, type: item.Type })
+    currentParentType.value = item.Type
+    emit('navigation-change', item.Name)
     await fetchItems(item.Id)
   }
 }
 
+const topSentinel = ref<HTMLElement | null>(null)
 const sentinel = ref<HTMLElement | null>(null)
 let observer: IntersectionObserver | null = null
 
 function setupObserver() {
   if (observer) observer.disconnect()
   observer = new IntersectionObserver((entries) => {
-    if (entries[0]?.isIntersecting && hasMore.value && !loadingMore.value) {
-      loadMore()
+    for (const entry of entries) {
+      if (!entry.isIntersecting) continue
+      if (entry.target === topSentinel.value) {
+        loadPrevious()
+      } else if (entry.target === sentinel.value) {
+        loadMore()
+      }
     }
   }, { rootMargin: '200px' })
 }
 
-watch(sentinel, (el) => {
-  if (observer) observer.disconnect()
-  if (el && observer) observer.observe(el)
+watch([topSentinel, sentinel], ([top, bottom]) => {
+  if (!observer) return
+  observer.disconnect()
+  if (top) observer.observe(top)
+  if (bottom) observer.observe(bottom)
 })
 
-watch(hasMore, async (val) => {
-  if (val) {
-    await nextTick()
-    if (sentinel.value && observer) observer.observe(sentinel.value)
-  }
+watch([hasPrevious, hasMore], async () => {
+  await nextTick()
+  if (!observer) return
+  observer.disconnect()
+  if (topSentinel.value) observer.observe(topSentinel.value)
+  if (sentinel.value) observer.observe(sentinel.value)
 })
 
 async function restoreOrFetchRoot() {
@@ -612,15 +657,21 @@ async function restoreOrFetchRoot() {
   // valid destination and used to wipe the LibraryState on every
   // mount here, silently discarding the user's browsing position.
   breadcrumbs.value = saved.breadcrumbs
+  currentParentType.value = saved.breadcrumbs.at(-1)?.type ?? null
+  emit('navigation-change', saved.breadcrumbs.at(-1)?.name ?? 'Libraries')
   const status = await fetchItems(saved.parentId)
   if (status === 'error') {
     bumpNavToken('restoreOrFetchRoot:fallback')
     clearLibraryState()
     breadcrumbs.value = []
     currentParentId.value = null
+    currentParentType.value = null
+    emit('navigation-change', 'Libraries')
     await fetchLibraries()
   }
 }
+
+defineExpose({ goToRoot })
 
 onMounted(() => {
   setupObserver()
@@ -775,38 +826,6 @@ onUnmounted(() => {
 
 .alphabet-letter:hover:not(:disabled) {
   background: var(--accent-primary-dim);
-}
-
-/* Active state when the right-click filter is pinned to this letter.
-   Inverted colour so it reads as "this is what's currently selected"
-   at a glance even on a dense column of letters. Adds a glow pulse so
-   the active letter visibly draws the eye -- ~1.2s breathing cycle,
-   slow enough not to read as a strobe but fast enough to be noticeable
-   in peripheral vision while the user is scanning cards. */
-.alphabet-letter.active {
-  background: var(--accent-primary);
-  color: var(--bg-deep);
-  animation: alphabet-pulse 1.2s ease-in-out infinite;
-}
-
-@keyframes alphabet-pulse {
-  0%, 30% {
-    box-shadow: 0 0 0 0 var(--accent-primary-glow);
-    background: var(--accent-primary);
-  }
-  100% {
-    box-shadow: 0 0 6px 2px var(--accent-primary-glow);
-    background: #67e8f9;
-  }
-}
-
-/* Respect users who disabled motion in their OS -- show the active
-   state as a static glow without the looping animation. */
-@media (prefers-reduced-motion: reduce) {
-  .alphabet-letter.active {
-    animation: none;
-    box-shadow: 0 0 6px 2px var(--accent-primary-glow);
-  }
 }
 
 .alphabet-letter.dim,
@@ -1032,5 +1051,55 @@ onUnmounted(() => {
   color: var(--text-muted);
   font-size: 0.85rem;
   overflow-anchor: none;
+}
+
+@media (max-width: 760px) {
+  .library-browser,
+  .panel-header,
+  .search-bar,
+  .library-content,
+  .items-grid {
+    min-width: 0;
+    max-width: 100%;
+  }
+
+  .panel-header {
+    margin-bottom: var(--space-sm);
+  }
+
+  .search-bar input {
+    min-width: 0;
+  }
+
+  .search-bar button {
+    flex-shrink: 0;
+    padding-inline: 10px;
+  }
+
+  .library-content {
+    gap: 6px;
+  }
+
+  .items-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.5rem;
+  }
+
+  .alphabet-bar {
+    right: 0;
+    max-height: calc(100dvh - 170px - env(safe-area-inset-top));
+    overflow-y: auto;
+    scrollbar-width: none;
+  }
+
+  .alphabet-bar::-webkit-scrollbar {
+    display: none;
+  }
+
+  .alphabet-letter {
+    width: 20px;
+    height: 18px;
+    flex-shrink: 0;
+  }
 }
 </style>

--- a/frontend/src/composables/usePartyStream.test.ts
+++ b/frontend/src/composables/usePartyStream.test.ts
@@ -3,6 +3,7 @@ import { mount } from '@vue/test-utils'
 import { describe, expect, it, vi } from 'vitest'
 
 import { api } from '@/api/client'
+import type { StreamsResponse } from '@/api/client'
 import { usePartyStream } from './usePartyStream'
 
 describe('usePartyStream', () => {
@@ -51,6 +52,68 @@ describe('usePartyStream', () => {
       )
     })
 
+    wrapper.unmount()
+  })
+
+  it('does not duplicate a subtitle selected while preload is pending', async () => {
+    let resolveStreams!: (streams: StreamsResponse) => void
+    vi.spyOn(api, 'itemStreams').mockReturnValue(new Promise((resolve) => {
+      resolveStreams = resolve
+    }))
+    const party = reactive<{
+      partyId: string | null
+      currentVideo: { item_id: string; media_source_id: string } | null
+      myStreamUrl: string | null
+    }>({
+      partyId: 'PARTY',
+      currentVideo: null,
+      myStreamUrl: null,
+    })
+    let video: HTMLVideoElement | null = null
+    let stream!: ReturnType<typeof usePartyStream>
+
+    const wrapper = mount(defineComponent({
+      setup() {
+        stream = usePartyStream(
+          { emit: vi.fn() } as never,
+          party as never,
+          vi.fn(),
+          () => video,
+        )
+        return () => h('video', { ref: (element: unknown) => { video = element as HTMLVideoElement } })
+      },
+    }))
+
+    party.currentVideo = { item_id: 'item-1', media_source_id: 'source-b' }
+    party.myStreamUrl = '/hls/item-1/master.m3u8'
+    await nextTick()
+    await vi.waitFor(() => expect(api.itemStreams).toHaveBeenCalled())
+
+    stream.changeTextSubtitle({
+      index: 3,
+      url: '/api/subtitles/item-1/source-b/3',
+    })
+    expect(wrapper.findAll('track')).toHaveLength(1)
+
+    resolveStreams({
+      audio: [],
+      subtitles: [{
+        index: 3,
+        language: 'eng',
+        displayLanguage: 'English',
+        codec: 'subrip',
+        isDefault: false,
+        isForced: false,
+        isExternal: true,
+        isPGS: false,
+        isTextSubtitleStream: true,
+        title: 'English',
+      }],
+      media_source_id: 'source-b',
+      versions: [],
+    })
+
+    await vi.waitFor(() => expect(wrapper.findAll('track')).toHaveLength(1))
     wrapper.unmount()
   })
 })

--- a/frontend/src/composables/usePartyStream.ts
+++ b/frontend/src/composables/usePartyStream.ts
@@ -158,6 +158,8 @@ export function usePartyStream(
 
       try {
         const streams = await loadSubtitleStreams(itemId, mediaSourceId)
+        if (lastSubtitlePreloadKey !== key) return
+        video.querySelectorAll('track').forEach((track) => track.remove())
         const textSubtitles = streams.subtitles.filter(
           (stream) => !stream.isPGS && stream.isTextSubtitleStream,
         )

--- a/frontend/src/views/PartyView.vue
+++ b/frontend/src/views/PartyView.vue
@@ -147,6 +147,8 @@ const joined = ref(false)
 // confirms the auto-join, even when localStorage has a saved name.
 const awaitingAutoJoin = ref(!!localStorage.getItem(STORAGE_KEY))
 const showLibrary = ref(false)
+const libraryLocation = ref('Libraries')
+const libraryBrowser = ref<{ goToRoot: () => Promise<void> } | null>(null)
 const copyLabel = ref('Copy')
 const showVersionModal = ref(false)
 const videoPlayer = ref<InstanceType<typeof VideoPlayer> | null>(null)
@@ -981,6 +983,10 @@ function toggleLibrary() {
   }
 }
 
+function goToAllLibraries() {
+  void libraryBrowser.value?.goToRoot()
+}
+
 function libraryButtonAction() {
   if (auth.partyUnlocked) {
     toggleLibrary()
@@ -1045,7 +1051,7 @@ async function submitBecomeHost(payload: { username: string; password: string })
   </div>
 
   <!-- Party room -->
-  <div v-if="joined" class="party-container">
+  <div v-if="joined" class="party-container" :class="{ 'library-open': showLibrary }">
     <!-- Reconnecting banner: shown when the socket has dropped and
          socket.io-client is attempting to reconnect. Without this, a
          mid-party disconnect looks identical to a healthy connection
@@ -1184,12 +1190,26 @@ async function submitBecomeHost(payload: { username: string; password: string })
       </div>
     </header>
 
+    <header v-if="showLibrary" class="mobile-library-header">
+      <button type="button" class="mobile-library-btn" @click="goToAllLibraries">
+        All Libraries
+      </button>
+      <span class="mobile-library-location" :title="libraryLocation">
+        {{ libraryLocation }}
+      </span>
+      <button type="button" class="mobile-library-btn" @click="toggleLibrary">
+        Hide Library
+      </button>
+    </header>
+
     <div class="party-content">
       <!-- Library panel -->
       <LibraryBrowser
         v-if="showLibrary"
+        ref="libraryBrowser"
         class="library-panel"
         @select-video="selectVideo"
+        @navigation-change="libraryLocation = $event"
       />
 
       <!-- Video area -->
@@ -1662,6 +1682,10 @@ async function submitBecomeHost(payload: { username: string; password: string })
   border-bottom: 1px solid var(--border-subtle);
   position: relative;
   z-index: 10;
+}
+
+.mobile-library-header {
+  display: none;
 }
 
 .header-left {
@@ -2394,6 +2418,49 @@ async function submitBecomeHost(payload: { username: string; password: string })
 }
 
 @media (max-width: 760px) {
+  .party-container.library-open .party-header {
+    display: none;
+  }
+
+  .mobile-library-header {
+    display: flex;
+    align-items: center;
+    gap: var(--space-sm);
+    flex-shrink: 0;
+    min-height: calc(52px + env(safe-area-inset-top));
+    padding: env(safe-area-inset-top)
+      max(var(--space-sm), env(safe-area-inset-right)) 0
+      max(var(--space-sm), env(safe-area-inset-left));
+    background: rgba(11, 14, 28, 0.92);
+    border-bottom: 1px solid var(--border-subtle);
+    backdrop-filter: blur(20px) saturate(180%);
+    -webkit-backdrop-filter: blur(20px) saturate(180%);
+    z-index: 10;
+  }
+
+  .mobile-library-btn {
+    flex-shrink: 0;
+    min-height: 36px;
+    padding: 6px 10px;
+    border: 1px solid var(--border-subtle);
+    border-radius: 9px;
+    background: var(--bg-surface);
+    color: var(--text-primary);
+    font: 600 12px var(--font-sans);
+    cursor: pointer;
+  }
+
+  .mobile-library-location {
+    min-width: 0;
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    text-align: center;
+    color: var(--text-secondary);
+    font-size: 12px;
+  }
+
   .party-header {
     align-items: flex-start;
     gap: var(--space-sm);
@@ -2420,6 +2487,12 @@ async function submitBecomeHost(payload: { username: string; password: string })
   .library-panel {
     width: 100%;
     min-width: 0;
+    height: 100%;
+    overflow-x: hidden;
+  }
+
+  .party-container.library-open .video-area {
+    display: none;
   }
 
   .chat-panel {

--- a/frontend/src/views/PartyView.vue
+++ b/frontend/src/views/PartyView.vue
@@ -2417,6 +2417,71 @@ async function submitBecomeHost(payload: { username: string; password: string })
   display: none;
 }
 
+/* Browser zoom and compact desktop windows can leave fewer than 1,100
+   CSS pixels even on a physically large monitor. A permanent 320px chat
+   column then starves the player and makes the controls wrap vertically.
+   Use the existing chat drawer at this intermediate breakpoint while
+   retaining the normal desktop library layout. */
+@media (max-width: 1280px) {
+  .brand-name {
+    display: none;
+  }
+
+  .party-header,
+  .header-left,
+  .header-actions {
+    gap: var(--space-sm);
+  }
+
+  .mobile-chat-toggle {
+    display: inline-flex;
+  }
+
+  .chat-panel {
+    position: fixed;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    width: min(92vw, 360px);
+    max-width: 100vw;
+    z-index: 1001;
+    transform: translateX(100%);
+    transition: transform var(--transition-fast);
+    box-shadow: var(--shadow-lg);
+    padding-bottom: env(safe-area-inset-bottom);
+  }
+
+  .chat-panel.chat-mobile-open {
+    transform: translateX(0);
+  }
+
+  .chat-close-btn {
+    display: inline-flex;
+  }
+
+  .chat-backdrop {
+    display: block;
+    position: fixed;
+    inset: 0;
+    z-index: 1000;
+    background: rgba(0, 0, 0, 0.45);
+    border: 0;
+    padding: 0;
+    cursor: pointer;
+  }
+}
+
+@media (min-width: 761px) and (max-width: 1280px) {
+  .video-wrapper {
+    overflow-y: auto;
+  }
+
+  .video-wrapper :deep(.video-player) {
+    flex: 0 0 100%;
+    min-height: 100%;
+  }
+}
+
 @media (max-width: 760px) {
   .party-container.library-open .party-header {
     display: none;

--- a/tests/support/fake_emby.py
+++ b/tests/support/fake_emby.py
@@ -185,7 +185,13 @@ def create_fake_emby_app(state: FakeEmbyState | None = None) -> FastAPI:
         state.record(request)  # Never retain submitted credentials.
         if failure := await state.before(request):
             return failure
-        user_id = "user-large" if credentials.get("Username") == "LargeLibrary" else "user-1"
+        username = credentials.get("Username")
+        if username == "LargeLibrary":
+            user_id = "user-large"
+        elif username == "AlphabetLibrary":
+            user_id = "user-alphabet"
+        else:
+            user_id = "user-1"
         return {
             "AccessToken": "fake-access-token",
             "User": {
@@ -226,23 +232,59 @@ def create_fake_emby_app(state: FakeEmbyState | None = None) -> FastAPI:
         state.record(request)
         return {"Items": [{"Id": "library-1", "Name": "Movies", "CollectionType": "movies"}]}
 
+    @app.get("/emby/Items/Prefixes")
+    async def item_prefixes(request: Request):
+        state.record(request)
+        return [
+            {"Name": "#", "Value": None},
+            {"Name": "A", "Value": None},
+            {"Name": "M", "Value": None},
+            {"Name": "Z", "Value": None},
+        ]
+
     @app.get("/emby/Users/{user_id}/Items")
     async def user_items(request: Request, user_id: str):
         state.record(request)
-        if user_id != "user-large":
+        if user_id not in {"user-large", "user-alphabet"}:
             return {"Items": [MOVIE], "TotalRecordCount": 1}
 
-        catalog = [
-            {
-                **MOVIE,
-                "Id": f"large-{index:04d}",
-                "Name": f"Large Movie {index:04d}",
-            }
-            for index in range(500)
-        ]
+        if user_id == "user-alphabet":
+            catalog: list[dict[str, Any]] = []
+            for prefix, count in (
+                ("# Feature", 25),
+                ("Alpha Movie", 75),
+                ("Middle Movie", 150),
+                ("Zulu Movie", 150),
+            ):
+                for index in range(count):
+                    name = f"{prefix} {index:04d}"
+                    catalog.append(
+                        {
+                            **MOVIE,
+                            "Id": f"alphabet-{len(catalog):04d}",
+                            "Name": name,
+                            "SortName": name,
+                        }
+                    )
+        else:
+            catalog = [
+                {
+                    **MOVIE,
+                    "Id": f"large-{index:04d}",
+                    "Name": f"Large Movie {index:04d}",
+                }
+                for index in range(500)
+            ]
         search_term = request.query_params.get("SearchTerm", "").casefold()
         if search_term:
             catalog = [item for item in catalog if search_term in item["Name"].casefold()]
+        name_less_than = request.query_params.get("NameLessThan")
+        if name_less_than:
+            boundary = name_less_than.casefold()
+            preceding = [
+                item for item in catalog if item.get("SortName", item["Name"]).casefold() < boundary
+            ]
+            return {"Items": preceding[:1], "TotalRecordCount": len(preceding)}
         start = int(request.query_params.get("StartIndex", 0))
         limit = int(request.query_params.get("Limit", len(catalog)))
         return {

--- a/tests/test_admin_session_security.py
+++ b/tests/test_admin_session_security.py
@@ -130,9 +130,7 @@ def test_failed_config_save_does_not_enable_static_session_in_memory(
             )
 
             assert saved.json()["success"] is False
-            assert (await client.get("/api/party/static-session")).json() == {
-                "party_id": None
-            }
+            assert (await client.get("/api/party/static-session")).json() == {"party_id": None}
             assert application.state.party_manager.get("PARTY") is None
 
     asyncio.run(exercise())
@@ -155,9 +153,7 @@ def test_enabling_static_session_creates_static_party(
             )
 
             assert saved.json()["success"] is True
-            assert (await client.get("/api/party/static-session")).json() == {
-                "party_id": "PARTY"
-            }
+            assert (await client.get("/api/party/static-session")).json() == {"party_id": "PARTY"}
             assert application.state.party_manager.get("PARTY") is not None
 
     asyncio.run(exercise())

--- a/tests/test_admin_session_security.py
+++ b/tests/test_admin_session_security.py
@@ -103,6 +103,66 @@ def test_admin_login_keeps_emby_token_out_of_browser_cookie(tmp_path: Path) -> N
     asyncio.run(exercise())
 
 
+def test_failed_config_save_does_not_enable_static_session_in_memory(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """A failed disk write must not leave runtime config partially applied.
+
+    Otherwise the index redirects to the configured static party even though
+    PartyManager never created it, producing ``Party not found: PARTY`` after
+    refresh.
+    """
+
+    def fail_save(_runtime: RuntimeConfig) -> None:
+        raise OSError("config volume is read-only")
+
+    monkeypatch.setattr(RuntimeConfig, "save", fail_save)
+
+    async def exercise() -> None:
+        application = _application(tmp_path)
+        async with asgi_client(application) as client:
+            assert (await _login(client)).json()["success"] is True
+
+            saved = await client.put(
+                "/api/admin/config",
+                json={"STATIC_SESSION_ENABLED": True, "STATIC_SESSION_ID": "PARTY"},
+            )
+
+            assert saved.json()["success"] is False
+            assert (await client.get("/api/party/static-session")).json() == {
+                "party_id": None
+            }
+            assert application.state.party_manager.get("PARTY") is None
+
+    asyncio.run(exercise())
+
+
+def test_enabling_static_session_creates_static_party(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(RuntimeConfig, "save", lambda _runtime: None)
+
+    async def exercise() -> None:
+        application = _application(tmp_path)
+        async with asgi_client(application) as client:
+            assert (await _login(client)).json()["success"] is True
+
+            saved = await client.put(
+                "/api/admin/config",
+                json={"STATIC_SESSION_ENABLED": True, "STATIC_SESSION_ID": "PARTY"},
+            )
+
+            assert saved.json()["success"] is True
+            assert (await client.get("/api/party/static-session")).json() == {
+                "party_id": "PARTY"
+            }
+            assert application.state.party_manager.get("PARTY") is not None
+
+    asyncio.run(exercise())
+
+
 def test_admin_logout_revokes_server_side_session(tmp_path: Path) -> None:
     async def exercise() -> None:
         async with asgi_client(_application(tmp_path)) as client:

--- a/tests/test_deployment_artifacts.py
+++ b/tests/test_deployment_artifacts.py
@@ -39,6 +39,37 @@ def test_compose_uses_production_safe_schema_defaults() -> None:
     assert len(compose["services"]) == 1
 
 
+def test_checked_in_platform_artifacts_match_the_schema_contract() -> None:
+    paths = (
+        Path("docker-compose.yml.example"),
+        Path("deploy/casaos/docker-compose.yml"),
+        Path("deploy/truenas/custom-app.yml"),
+    )
+    expected_image = f"{SCHEMA['image']['repository']}:{SCHEMA['image']['tag']}"
+    expected_targets = [item["target"] for item in SCHEMA["storage"]]
+    container_port = SCHEMA["application"]["container_port"]
+
+    for path in paths:
+        model = yaml.safe_load((ROOT / path).read_text(encoding="utf-8"))
+        service = model["services"]["emby-watchparty"]
+        mounted_targets = [entry.rsplit(":", 1)[1] for entry in service["volumes"]]
+
+        assert service["image"] == expected_image, path
+        assert list(service["environment"]) == EMITTED_NAMES, path
+        assert service["environment"]["WATCH_PARTY_BIND"] == "0.0.0.0", path
+        assert service["environment"]["WATCH_PARTY_PORT"] == str(container_port), path
+        assert mounted_targets == expected_targets, path
+        assert "WEB_CONCURRENCY" not in service["environment"], path
+        assert "command" not in service, path
+
+        if path == Path("deploy/casaos/docker-compose.yml"):
+            assert service["ports"] == [
+                {"target": container_port, "published": str(container_port), "protocol": "tcp"}
+            ]
+        else:
+            assert service["ports"] == [f"{container_port}:{container_port}"], path
+
+
 def test_generated_examples_never_contain_secret_values() -> None:
     artifacts = generate_artifacts(SCHEMA)
     combined = "\n".join(artifacts.values())

--- a/tests/test_deployment_artifacts.py
+++ b/tests/test_deployment_artifacts.py
@@ -173,6 +173,20 @@ def test_check_mode_detects_missing_and_changed_artifacts(tmp_path: Path, capsys
     assert "deploy/casaos/docker-compose.yml" in output
 
 
+def test_check_mode_ignores_operator_copies_of_top_level_examples(tmp_path: Path, capsys) -> None:
+    assert main(["--output-dir", str(tmp_path)]) == 0
+    (tmp_path / ".env").write_text(
+        (tmp_path / ".env.example").read_text(encoding="utf-8"), encoding="utf-8"
+    )
+    (tmp_path / "docker-compose.yml").write_text(
+        (tmp_path / "docker-compose.yml.example").read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+
+    assert main(["--output-dir", str(tmp_path), "--check"]) == 0
+    assert "extra deployment artifact" not in capsys.readouterr().out
+
+
 def test_check_mode_detects_obsolete_generated_artifact(tmp_path: Path, capsys) -> None:
     assert main(["--output-dir", str(tmp_path)]) == 0
     obsolete = tmp_path / "deploy" / "obsolete.yml"

--- a/tests/test_deployment_schema.py
+++ b/tests/test_deployment_schema.py
@@ -284,6 +284,28 @@ def test_a_deployment_built_from_the_env_example_actually_boots() -> None:
         os.environ.update(saved)
 
 
+def test_committed_env_example_boots_through_the_real_loader(tmp_path: Path) -> None:
+    """The checked-in operator artifact must preserve intentional absence."""
+    import os
+
+    (tmp_path / ".env").write_text(
+        (ROOT / ".env.example").read_text(encoding="utf-8") + "\nAPP_ENV=development\n",
+        encoding="utf-8",
+    )
+
+    saved = dict(os.environ)
+    os.environ.clear()
+    try:
+        errors: dict[str, str] = {}
+        env = EnvConfig.from_env(tmp_path, errors=errors)
+        assert env.BEHIND_PROXY is None
+        assert env.SESSION_COOKIE_SECURE is False
+        assert Config(env, RuntimeConfig(), load_errors=errors).startup_errors() == {}
+    finally:
+        os.environ.clear()
+        os.environ.update(saved)
+
+
 def test_validation_patterns_agree_with_the_loader_they_describe() -> None:
     """The schema is a third description of config.py's rules; pin them together.
 

--- a/tests/test_deployment_schema.py
+++ b/tests/test_deployment_schema.py
@@ -361,5 +361,12 @@ def test_storage_drives_the_generated_volume_mounts() -> None:
             "writable": True,
         }
     )
-    rendered = generate_artifacts(extended)[Path("docker-compose.yml.example")]
-    assert "/app/cache" in rendered
+    extended_artifacts = generate_artifacts(extended)
+    for path in (
+        Path("docker-compose.yml.example"),
+        Path("deploy/casaos/docker-compose.yml"),
+        Path("deploy/truenas/custom-app.yml"),
+    ):
+        service = yaml.safe_load(extended_artifacts[path])["services"]["emby-watchparty"]
+        mounted = {entry.rsplit(":", 1)[1] for entry in service["volumes"]}
+        assert "/app/cache" in mounted, path

--- a/tests/test_library_alphabet.py
+++ b/tests/test_library_alphabet.py
@@ -1,0 +1,73 @@
+import httpx
+
+
+def _unlocked_client(live_watchparty) -> httpx.Client:
+    client = httpx.Client(base_url=live_watchparty.url)
+    created = client.post("/api/party/create", json={})
+    created.raise_for_status()
+    party_id = created.json()["party_id"]
+    joined = client.post(
+        f"/api/party/{party_id}/join",
+        json={"client_id": "alphabet-client", "display_name": "Alice"},
+    )
+    joined.raise_for_status()
+    login = client.post(
+        "/api/auth/login",
+        json={"username": "AlphabetLibrary", "password": "password"},
+    )
+    login.raise_for_status()
+    assert login.json()["success"] is True
+    return client
+
+
+def test_library_prefixes_follow_the_browsed_collection_scope(live_watchparty) -> None:
+    client = _unlocked_client(live_watchparty)
+    try:
+        response = client.get("/api/items/prefixes", params={"parentId": "library-1"})
+    finally:
+        client.close()
+
+    assert response.status_code == 200
+    assert response.json() == {"Prefixes": ["#", "A", "M", "Z"]}
+
+    recorded = httpx.get(f"{live_watchparty.fake.url}/__test__/requests").json()["requests"]
+    prefix_request = next(row for row in recorded if row["path"] == "/emby/Items/Prefixes")
+    query = dict(prefix_request["query"])
+    assert query["UserId"] == "user-alphabet"
+    assert query["ParentId"] == "library-1"
+    assert query["Recursive"] == "true"
+    assert query["IncludeItemTypes"] == "Movie"
+
+
+def test_letter_jump_returns_an_absolute_page_in_alphabetical_order(live_watchparty) -> None:
+    client = _unlocked_client(live_watchparty)
+    try:
+        response = client.get(
+            "/api/items",
+            params={
+                "parentId": "library-1",
+                "limit": 50,
+                "sortMode": "alphabetical",
+                "anchorPrefix": "M",
+            },
+        )
+    finally:
+        client.close()
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["StartIndex"] == 100
+    assert body["Items"][0]["Name"] == "Middle Movie 0000"
+
+    recorded = httpx.get(f"{live_watchparty.fake.url}/__test__/requests").json()["requests"]
+    item_requests = [
+        dict(row["query"]) for row in recorded if row["path"] == "/emby/Users/user-alphabet/Items"
+    ]
+    count_query = next(query for query in item_requests if "NameLessThan" in query)
+    page_query = next(query for query in item_requests if query.get("StartIndex") == "100")
+
+    assert count_query["NameLessThan"] == "M"
+    assert count_query["Limit"] == "1"
+    assert count_query["SortBy"] == "SortName"
+    assert page_query["SortBy"] == "SortName"
+    assert "SortName" in page_query["Fields"].split(",")

--- a/tests/test_log_redaction.py
+++ b/tests/test_log_redaction.py
@@ -72,6 +72,41 @@ def test_admin_login_logs_redact_upstream_credentials(
     assert "ConnectError" in caplog.text
 
 
+def test_party_login_reports_unreachable_emby_without_blending_with_credentials(
+    tmp_path: Path,
+) -> None:
+    async def exercise() -> None:
+        app = create_app(
+            config=_config(),
+            project_root=tmp_path,
+            enable_update_check=False,
+            http_transport=SensitiveFailureTransport(),
+        )
+        async with asgi_client(app) as client:
+            party_id = (await client.post("/api/party/create", json={})).json()["party_id"]
+            await client.post(
+                f"/api/party/{party_id}/join",
+                json={"client_id": "unreachable-emby", "display_name": "Operator"},
+            )
+
+            response = await client.post(
+                "/api/auth/login",
+                json={"username": "operator", "password": "submitted-password"},
+            )
+
+        assert response.status_code == 200
+        assert response.json() == {
+            "success": False,
+            "message": "Emby server unavailable; ask the operator to verify EMBY_SERVER_URL",
+            "username": None,
+            "is_admin": False,
+            "is_host": False,
+            "host_username": None,
+        }
+
+    asyncio.run(exercise())
+
+
 def test_uvicorn_access_logger_is_silenced_for_every_entrypoint(tmp_path: Path) -> None:
     """uvicorn's own access logger must never run.
 

--- a/tests/test_production_config.py
+++ b/tests/test_production_config.py
@@ -34,6 +34,32 @@ def _config(runtime: RuntimeConfig | None = None, **overrides) -> Config:
     return Config(EnvConfig(**values), runtime or RuntimeConfig())
 
 
+def test_failed_runtime_save_rolls_back_every_field_type() -> None:
+    runtime = RuntimeConfig(
+        STATIC_SESSION_ENABLED=False,
+        STATIC_SESSION_ID="PARTY",
+        LOG_MAX_SIZE=10,
+        ENABLED_QUALITY_OPTIONS={"720p": [4000]},
+    )
+    config = _config(runtime=runtime)
+    before = runtime.to_dict()
+
+    with (
+        mock.patch.object(RuntimeConfig, "save", side_effect=OSError("read-only config")),
+        pytest.raises(OSError, match="read-only config"),
+    ):
+        config.update_runtime(
+            {
+                "STATIC_SESSION_ENABLED": True,
+                "STATIC_SESSION_ID": "LOUNGE",
+                "LOG_MAX_SIZE": 25,
+                "ENABLED_QUALITY_OPTIONS": {"1080p": [10000, 8000]},
+            }
+        )
+
+    assert runtime.to_dict() == before
+
+
 class UpstreamHostnameTests(unittest.TestCase):
     """`EMBY_SERVER_URL` addresses a container, not a public host.
 

--- a/tests/test_socket_responsiveness.py
+++ b/tests/test_socket_responsiveness.py
@@ -106,17 +106,21 @@ async def _exercise_progress_coalescing(live_watchparty) -> None:
             await realtime.emit("report_progress", {"party_id": party_id, "time": 12.0})
             await realtime.emit("report_progress", {"party_id": party_id, "time": 34.0})
 
+            progress_reports = []
             for _ in range(50):
                 state = (await client.get(f"/api/party/{party_id}/info")).json()
-                if state["playback_state"]["time"] == 34.0:
+                progress_reports = [
+                    request
+                    for request in live_watchparty.fake.state.requests
+                    if request["path"] == "/emby/Sessions/Playing/Progress"
+                ]
+                # Party state commits before the async Emby report finishes.
+                # Wait for both observable effects; checking the request list
+                # immediately after state advanced raced on faster CI hosts.
+                if state["playback_state"]["time"] == 34.0 and progress_reports:
                     break
                 await asyncio.sleep(0.02)
             assert state["playback_state"]["time"] == 34.0
-            progress_reports = [
-                request
-                for request in live_watchparty.fake.state.requests
-                if request["path"] == "/emby/Sessions/Playing/Progress"
-            ]
             assert len(progress_reports) == 1
             # WHICH report survived, not just how many. The handler throttles
             # by dropping anything inside the window, so the report that


### PR DESCRIPTION
## Description

Hardens appliance deployment consistency, distinguishes Emby outages from invalid credentials, makes runtime configuration saves transactional, and repairs mobile/desktop library navigation.

Changes include:

- Correct Unraid template ownership and appliance documentation; add schema/drift coverage for shipped deployment artifacts and environment examples.
- Preserve explicit Emby-unavailable errors across admin, host, and party login flows.
- Deep-snapshot runtime configuration before updates and restore scalar and collection fields if persistence fails.
- Ensure successful static-session saves create the party and failed saves cannot expose a nonexistent party.
- Exercise authenticated HLS requests through browser sessions, synchronize iOS joining before host login, and isolate E2E cookie security from operator `.env` settings.
- Prevent async subtitle preloading from duplicating a track selected while preload is pending.
- Replace the wrapped mobile party header with compact library navigation, keeping search, posters, and the alphabet rail inside the viewport.
- Back alphabet navigation with Emby prefixes and `SortName` pagination, including direct letter jumps and backward/forward incremental loading without disturbing season or episode ordering.
- Migrate legacy saved library breadcrumbs so the prefix rail loads after upgrades, pin jumps to each prefix's first title, and compress the rail for short desktop/mobile viewports.
- Give compact desktop video the available content height and move chat into an overlay drawer so chat and controls do not squeeze the player.
- Add authenticated prefix/anchored paging API contracts, Chromium and iPhone WebKit regressions, user-facing release notes, and a checked local `docker-compose.yml` using environment placeholders for credentials.

This PR targets the active integration branch, `3.0-dev`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Dependencies update

## Related Issues

None.

## Testing

Reported from the repository root with `.venv` active (Python 3.12):

- `python -m ruff check backend scripts tests`
- `python -m ruff format --check backend scripts tests` — 78 files formatted
- `python -m mypy` — 44 source files
- `python -m pytest` — 208 passed
- `python scripts/generate_socket_types.py --check`
- `python scripts/generate_deployment_artifacts.py --check`
- `docker compose -f docker-compose.yml config --quiet`

Reported from `frontend/`:

- `npm run lint`
- `npm run type-check`
- `npm run test:unit` — 32 passed
- `npm run build-only`
- `npm run test:e2e` — 26 passed across Chromium, Firefox, desktop WebKit, and iPhone WebKit

- [x] I have tested these changes locally
- [x] I have added/updated tests as needed

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] I have updated documentation as needed
- [x] My changes generate no new warnings
